### PR TITLE
Resolve access violation error in obs_frontend_event_handler

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -354,15 +354,21 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *)
 		{
 			obs_source_t *source = obs_frontend_get_current_scene();
 
-			Json json = Json::object {
-				{"name", obs_source_get_name(source)},
-				{"width", (int)obs_source_get_width(source)},
-				{"height", (int)obs_source_get_height(source)}
-			};
+			if (source) {
+				const char* sourceName = obs_source_get_name(source);
 
-			obs_source_release(source);
+				if (sourceName) {
+					Json json = Json::object{
+						{"name", sourceName},
+						{"width", (int)obs_source_get_width(source)},
+						{"height", (int)obs_source_get_height(source)}
+					};
 
-			DispatchJSEvent("obsSceneChanged", json.dump().c_str());
+					DispatchJSEvent("obsSceneChanged", json.dump().c_str());
+				}
+
+				obs_source_release(source);
+			}
 			break;
 		}
 	case OBS_FRONTEND_EVENT_EXIT:

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -445,12 +445,7 @@ void DispatchJSEvent(const char *eventName, const char *jsonString)
 	class local_context: public CefBaseRefCounted {
 	public:
 		std::string eventName;
-		char* jsonString = nullptr;
-
-		~local_context()
-		{
-			if (jsonString) delete jsonString;
-		}
+		std::string jsonString = "null";
 
 		IMPLEMENT_REFCOUNTING(local_context)
 	};
@@ -461,8 +456,12 @@ void DispatchJSEvent(const char *eventName, const char *jsonString)
 
 	context->eventName = eventName;
 
-	if (jsonString)
-		context->jsonString = strdup(jsonString);
+	if (jsonString) {
+		context->jsonString = jsonString;
+	}
+	else {
+		context->jsonString = "null";
+	}
 
 	auto func = [context](BrowserSource *bsw)
 	{

--- a/streamelements/StreamElementsAnalyticsEventsManager.cpp
+++ b/streamelements/StreamElementsAnalyticsEventsManager.cpp
@@ -58,6 +58,10 @@ void StreamElementsAnalyticsEventsManager::Enqueue(task_queue_item_t task)
 
 void StreamElementsAnalyticsEventsManager::AddRawEvent(const char* eventName, json11::Json::object propertiesJson, bool synchronous)
 {
+	if (!eventName) {
+		return;
+	}
+
 	json11::Json::object props = propertiesJson;
 
 	uint64_t now = os_gettime_ns();

--- a/streamelements/StreamElementsAnalyticsEventsManager.hpp
+++ b/streamelements/StreamElementsAnalyticsEventsManager.hpp
@@ -18,12 +18,20 @@ public:
 	~StreamElementsAnalyticsEventsManager();
 
 	void trackSynchronousEvent(const char* eventName, json11::Json::object props = json11::Json::object{}) {
+		if (!eventName) {
+			return;
+		}
+
 		std::string event = std::string("OBS.Live Plugin: ") + eventName;
 
 		AddRawEvent(event.c_str(), props, true);
 	}
 
 	void trackEvent(const char* eventName, json11::Json::object props = json11::Json::object{}) {
+		if (!eventName) {
+			return;
+		}
+
 		std::string event = std::string("OBS.Live Plugin: ") + eventName;
 
 		AddRawEvent(event.c_str(), props, false);
@@ -31,6 +39,10 @@ public:
 
 	void trackDockWidgetEvent(QDockWidget* widget, const char* eventName, json11::Json::object props = json11::Json::object{})
 	{
+		if (!widget || !eventName) {
+			return;
+		}
+
 		std::string event = std::string("DockWidget: ") + widget->windowTitle().toStdString() + ": " + std::string(eventName);
 
 		trackEvent(event.c_str(), props);

--- a/streamelements/StreamElementsBrowserWidgetManager.cpp
+++ b/streamelements/StreamElementsBrowserWidgetManager.cpp
@@ -284,6 +284,10 @@ void StreamElementsBrowserWidgetManager::PushCentralBrowserWidget(
 	const char* const url,
 	const char* const executeJavaScriptCodeOnLoad)
 {
+	if (!url) {
+		return;
+	}
+
 	blog(LOG_INFO, "obs-browser: central widget: loading url: %s", url);
 
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -146,16 +146,22 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void* data)
 	{
 		obs_source_t *source = obs_frontend_get_current_scene();
 
-		json11::Json json = json11::Json::object{
-			{ "name", obs_source_get_name(source) },
-			{ "width", (int)obs_source_get_width(source) },
-			{ "height", (int)obs_source_get_height(source) }
-		};
+		if (source) {
+			const char* sourceName = obs_source_get_name(source);
 
-		obs_source_release(source);
+			if (sourceName) {
+				json11::Json json = json11::Json::object{
+					{ "name", sourceName },
+					{ "width", (int)obs_source_get_width(source) },
+					{ "height", (int)obs_source_get_height(source) }
+				};
 
-		name = "hostActiveSceneChanged";
-		args = json.dump();
+				name = "hostActiveSceneChanged";
+				args = json.dump();
+			}
+
+			obs_source_release(source);
+		}
 		break;
 	}
 	case OBS_FRONTEND_EVENT_EXIT:
@@ -165,7 +171,9 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void* data)
 		return;
 	}
 
-	StreamElementsCefClient::DispatchJSEvent(name, args);
+	if (name.size()) {
+		StreamElementsCefClient::DispatchJSEvent(name, args);
+	}
 }
 
 /* ========================================================================= */

--- a/streamelements/StreamElementsHotkeyManager.cpp
+++ b/streamelements/StreamElementsHotkeyManager.cpp
@@ -244,9 +244,14 @@ bool StreamElementsHotkeyManager::SerializeHotkeyBindings(CefRefPtr<CefValue>& o
 			auto weak = static_cast<obs_weak_source_t*>(item.registerer_ptr);
 			auto strong = obs_weak_source_get_source(weak);
 			if (strong) {
-				item.registerer = obs_source_get_name(strong);
+				const char* sourceName = obs_source_get_name(strong);
+
+				if (sourceName) {
+					item.registerer = sourceName;
+				}
+
+				obs_source_release(strong);
 			}
-			obs_source_release(strong);
 		}
 		break;
 		}


### PR DESCRIPTION
Add checks for obs_get_source_name() return value
Add checks for nullptr eventName and widget values in analytics backend
Add checks for recognized frontend event code
Add checks for nullptr DispatchJSEvent value (translate to 'null' JSON value)
Replace char* with std::string JSON data in DispatchJSEvent