### PR TITLE
obs-browser: prevent race condition in CEF paint pipeline

### DIFF
--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -42,7 +42,7 @@ class BrowserClient : public CefClient,
 	bool sharing_available = false;
 
 public:
-	BrowserSource *bs;
+	BrowserSource *bs = nullptr;
 	CefRect popupRect;
 	CefRect originalPopupRect;
 

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -67,7 +67,7 @@ struct BrowserSource {
 	/* ---------------------------- */
 
 	bool CreateBrowser();
-	void DestroyBrowser(bool async = false);
+	void DestroyBrowser();
 	void ExecuteOnBrowser(std::function<void()> func, bool async = false);
 
 	/* ---------------------------- */


### PR DESCRIPTION
* WasHidden & CloseBrowser are now called before bc->bs is
  dereferenced to disable calls to GetViewRect(), OnPaint() &
  OnAcceleratedPaint() earlier.
* WasHidden, CloseBrowser, Invalidate are now called in the current
  thread: execution on CEF UI thread is not required for those calls.
* In CEF paint pipeline (GetViewRect, OnPaint, OnAcceleratedPaint):
  Save the value of bc->bs befpre checking if it's valid to prevent the
  condition where bc->bs is checked for validity and immediately
  invalidated in a parallel thread.