### PR TITLE
Remove central widget stack, resolve compiler warnings

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -149,8 +149,10 @@ bool BrowserApp::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 		CefRefPtr<CefV8Value> globalObj = context->GetGlobal();
 		
 		Json::object json;
-		if (args->GetSize() > 1)
-			json["detail"] = Json::parse(args->GetString(1).ToString(), std::string());
+		if (args->GetSize() > 1) {
+			std::string err;
+			json["detail"] = Json::parse(args->GetString(1).ToString(), err);
+		}
 		std::string jsonString = Json(json).dump();
 
 		jsonString = StringReplaceAll(jsonString, "'", "\\u0027");

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -414,6 +414,7 @@ void BrowserSource::Render()
 #endif
 }
 
+/*
 static void ExecuteOnAllBrowsers(function<void(BrowserSource*)> func, bool async = false)
 {
 	lock_guard<mutex> lock(browser_list_mutex);
@@ -426,6 +427,7 @@ static void ExecuteOnAllBrowsers(function<void(BrowserSource*)> func, bool async
 		bs = bs->next;
 	}
 }
+*/
 
 void DispatchJSEvent(const char *eventName, const char *jsonString)
 {

--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -555,7 +555,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 					args->GetValue(0));
 
 			if (id != OBS_INVALID_HOTKEY_ID) {
-				result->SetInt(id);
+				result->SetInt((int)id);
 			}
 			else {
 				result->SetNull();
@@ -630,5 +630,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 	API_HANDLER_BEGIN("crashProgram")
 		// Crash
 		*((int*)nullptr) = 12345; // exception
+
+		UNUSED_PARAMETER(result);
 	API_HANDLER_END()
 }

--- a/streamelements/StreamElementsBandwidthTestClient.hpp
+++ b/streamelements/StreamElementsBandwidthTestClient.hpp
@@ -30,7 +30,7 @@ public:
 			authPassword(password != nullptr ? password : "")
 		{ }
 
-		Server(Server& other) :
+		Server(const Server& other) :
 			url(other.url),
 			streamKey(other.streamKey),
 			useAuth(other.useAuth),
@@ -50,7 +50,7 @@ public:
 		uint64_t connectTimeMilliseconds = 0L;
 
 		Result() { }
-		Result(Result& other):
+		Result(const Result& other):
 			success(other.success),
 			cancelled(other.cancelled),
 			serverUrl(other.serverUrl),
@@ -113,13 +113,14 @@ public:
 	void CancelAll();
 
 private:
-	Result TestServerBitsPerSecond(
+	void TestServerBitsPerSecond(
 		const char* serverUrl,
 		const char* streamKey,
 		const int maxBitrateBitsPerSecond,
-		const char* bindToIP = nullptr,
-		const int durationSeconds = 10,
-		const bool useAuth = false,
-		const char* const authUsername = nullptr,
-		const char* const authPassword = nullptr);
+		const char* bindToIP,
+		const int durationSeconds,
+		const bool useAuth,
+		const char* const authUsername,
+		const char* const authPassword,
+		StreamElementsBandwidthTestClient::Result* result);
 };

--- a/streamelements/StreamElementsBandwidthTestManager.cpp
+++ b/streamelements/StreamElementsBandwidthTestManager.cpp
@@ -65,7 +65,7 @@ bool StreamElementsBandwidthTestManager::BeginBandwidthTest(CefRefPtr<CefValue> 
 						}
 					}
 
-					m_last_test_servers.emplace_back(item);
+					m_last_test_servers.push_back(item);
 				}
 			}
 

--- a/streamelements/StreamElementsBrowserWidget.cpp
+++ b/streamelements/StreamElementsBrowserWidget.cpp
@@ -7,7 +7,7 @@
 #include <mutex>
 #include <regex>
 
-static class BrowserTask : public CefTask {
+class BrowserTask : public CefTask {
 public:
 	std::function<void()> task;
 

--- a/streamelements/StreamElementsBrowserWidget.hpp
+++ b/streamelements/StreamElementsBrowserWidget.hpp
@@ -216,7 +216,7 @@ private:
 		emit browserStateChanged();
 	}
 
-	static class StreamElementsBrowserWidget_EventHandler :
+	class StreamElementsBrowserWidget_EventHandler :
 		public StreamElementsCefClientEventHandler
 	{
 	public:
@@ -229,6 +229,11 @@ private:
 			bool canGoBack,
 			bool canGoForward) override
 		{
+			UNREFERENCED_PARAMETER(browser);
+			UNREFERENCED_PARAMETER(isLoading);
+			UNREFERENCED_PARAMETER(canGoBack);
+			UNREFERENCED_PARAMETER(canGoForward);
+
 			QtPostTask([](void* data) {
 				StreamElementsBrowserWidget* widget = (StreamElementsBrowserWidget*)data;
 

--- a/streamelements/StreamElementsBrowserWidgetManager.cpp
+++ b/streamelements/StreamElementsBrowserWidgetManager.cpp
@@ -112,13 +112,13 @@ public:
 		ensurePolished();
 		QStyleOptionTitleBar opt;
 		opt.init(this);
-		int marginSize = style()->pixelMetric(QStyle::PM_DockWidgetTitleMargin, &opt, this);
-		int frameSize = style()->pixelMetric(QStyle::PM_DockWidgetFrameWidth, &opt, this);
-		int iconSize = style()->pixelMetric(QStyle::PM_SmallIconSize, &opt, this);
+		//int marginSize = style()->pixelMetric(QStyle::PM_DockWidgetTitleMargin, &opt, this);
+		//int frameSize = style()->pixelMetric(QStyle::PM_DockWidgetFrameWidth, &opt, this);
+		//int iconSize = style()->pixelMetric(QStyle::PM_SmallIconSize, &opt, this);
 
 		int titleSize = titleHeight();
 
-		QDockWidget *w = qobject_cast<QDockWidget*>(parentWidget());
+		//QDockWidget *w = qobject_cast<QDockWidget*>(parentWidget());
 
 		QSize result = QSize(titleSize, titleSize);
 
@@ -759,7 +759,7 @@ void StreamElementsBrowserWidgetManager::DeserializeDockingWidgets(CefRefPtr<Cef
 				}
 			}
 
-			docksMap[area][start].emplace_back(id.ToString());
+			docksMap[area][start].push_back(id.ToString());
 			secondaryStartMap[id.ToString()] = secondary;
 		}
 	}
@@ -770,7 +770,7 @@ void StreamElementsBrowserWidgetManager::DeserializeDockingWidgets(CefRefPtr<Cef
 		std::string area = areaPair->first;
 
 		for (start_to_ids_map_t::iterator startPair = areaPair->second.begin(); startPair != areaPair->second.end(); ++startPair) {
-			int start = startPair->first;
+			//int start = startPair->first;
 			id_arr_t dockIds = startPair->second;
 
 			// 3. Sort dock IDs by secondary start coord

--- a/streamelements/StreamElementsCefClient.cpp
+++ b/streamelements/StreamElementsCefClient.cpp
@@ -19,6 +19,7 @@
 static std::recursive_mutex s_browsers_mutex;
 static std::vector<CefRefPtr<CefBrowser>> s_browsers;
 
+/*
 static class BrowserTask : public CefTask {
 public:
 	std::function<void()> task;
@@ -33,6 +34,7 @@ static bool QueueCEFTask(std::function<void()> task)
 {
 	return CefPostTask(TID_UI, CefRefPtr<BrowserTask>(new BrowserTask(task)));
 }
+*/
 
 /* ========================================================================= */
 
@@ -43,7 +45,7 @@ static bool SetWindowIconFromBuffer(cef_window_handle_t windowHandle, void* buff
 	if (offset) {
 		size_t size = buffer_len - offset;
 
-		HICON hIcon = ::CreateIconFromResourceEx((PBYTE)buffer + offset, size, TRUE, 0x00030000, 0, 0, LR_SHARED);
+		HICON hIcon = ::CreateIconFromResourceEx((PBYTE)buffer + offset, (DWORD)size, TRUE, 0x00030000, 0, 0, LR_SHARED);
 
 		if (hIcon) {
 			::SendMessage(windowHandle, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
@@ -71,7 +73,9 @@ static bool SetWindowIconFromResource(cef_window_handle_t windowHandle, QString&
 
 static bool SetWindowDefaultIcon(cef_window_handle_t windowHandle)
 {
-	return SetWindowIconFromResource(windowHandle, QString(":/images/icon.ico"));
+	QString icon(":/images/icon.ico");
+
+	return SetWindowIconFromResource(windowHandle, icon);
 }
 
 /* ========================================================================= */
@@ -233,6 +237,8 @@ void StreamElementsCefClient::OnTitleChange(CefRefPtr<CefBrowser> browser,
 void StreamElementsCefClient::OnFaviconURLChange(CefRefPtr<CefBrowser> browser,
 	const std::vector<CefString>& icon_urls)
 {
+	UNREFERENCED_PARAMETER(browser);
+	UNREFERENCED_PARAMETER(icon_urls);
 }
 
 void StreamElementsCefClient::OnAfterCreated(CefRefPtr<CefBrowser> browser)
@@ -243,7 +249,7 @@ void StreamElementsCefClient::OnAfterCreated(CefRefPtr<CefBrowser> browser)
 	{
 		std::lock_guard<std::recursive_mutex> guard(s_browsers_mutex);
 
-		s_browsers.emplace_back(browser);
+		s_browsers.push_back(browser);
 	}
 }
 
@@ -292,6 +298,9 @@ void StreamElementsCefClient::DispatchJSEvent(CefRefPtr<CefBrowser> browser, std
 bool StreamElementsCefClient::OnPreKeyEvent(CefRefPtr<CefBrowser> browser,
 	const CefKeyEvent& event, CefEventHandle os_event, bool* is_keyboard_shortcut)
 {
+	UNREFERENCED_PARAMETER(os_event);
+	UNREFERENCED_PARAMETER(is_keyboard_shortcut);
+
 	if (event.type != KEYEVENT_RAWKEYDOWN && event.type != KEYEVENT_KEYUP) {
 		return false;
 	}
@@ -331,8 +340,8 @@ bool StreamElementsCefClient::OnPreKeyEvent(CefRefPtr<CefBrowser> browser,
 		obs_interaction_flags obs;
 	};
 
-	const SHORT FLAG_PRESSED = 0x8000;
-	const SHORT FLAG_TOGGLED = 0x0001;
+	const USHORT FLAG_PRESSED = 0x8000;
+	const USHORT FLAG_TOGGLED = 0x0001;
 
 	// OBS hotkey thread currently supports only Ctrl, Shift, Alt modifiers.
 	//

--- a/streamelements/StreamElementsCefClient.hpp
+++ b/streamelements/StreamElementsCefClient.hpp
@@ -13,7 +13,12 @@ public:
 	virtual void OnLoadingStateChange(CefRefPtr<CefBrowser> browser,
 		bool isLoading,
 		bool canGoBack,
-		bool canGoForward) { }
+		bool canGoForward) {
+		UNREFERENCED_PARAMETER(browser);
+		UNREFERENCED_PARAMETER(isLoading);
+		UNREFERENCED_PARAMETER(canGoBack);
+		UNREFERENCED_PARAMETER(canGoForward);
+	}
 
 
 public:

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -114,6 +114,8 @@ void StreamElementsGlobalStateManager::ThemeChangeListener::changeEvent(QEvent* 
 
 static void handle_obs_frontend_event(enum obs_frontend_event event, void* data)
 {
+	UNUSED_PARAMETER(data);
+
 	std::string name;
 	std::string args = "null";
 
@@ -178,7 +180,7 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void* data)
 
 /* ========================================================================= */
 
-static class BrowserTask : public CefTask {
+class BrowserTask : public CefTask {
 public:
 	std::function<void()> task;
 
@@ -593,8 +595,7 @@ void StreamElementsGlobalStateManager::SwitchToOBSStudio()
 void StreamElementsGlobalStateManager::DeleteCookies()
 {
 	class CookieVisitor :
-		public CefCookieVisitor,
-		public CefBaseRefCounted
+		public CefCookieVisitor
 	{
 	public:
 		CookieVisitor() { }
@@ -602,6 +603,9 @@ void StreamElementsGlobalStateManager::DeleteCookies()
 
 		virtual bool Visit(const CefCookie& cookie, int count, int total, bool& deleteCookie) override
 		{
+			UNUSED_PARAMETER(count);
+			UNUSED_PARAMETER(total);
+
 			deleteCookie = true;
 
 			CefString domain(&cookie.domain);
@@ -740,7 +744,7 @@ void StreamElementsGlobalStateManager::RestoreState()
 	auto windowState = rootDictionary->GetValue("windowState");
 
 	if (geometry.get() && geometry->GetType() == VTYPE_STRING) {
-		blog(LOG_INFO, "obs-browser: state: restoring geometry: %s", geometry->GetString());
+		blog(LOG_INFO, "obs-browser: state: restoring geometry: %s", geometry->GetString().ToString().c_str());
 
 		mainWindow()->restoreGeometry(
 			QByteArray::fromStdString(base64_decode(geometry->GetString().ToString())));
@@ -752,7 +756,7 @@ void StreamElementsGlobalStateManager::RestoreState()
 	}
 
 	if (windowState.get() && windowState->GetType() == VTYPE_STRING) {
-		blog(LOG_INFO, "obs-browser: state: restoring windowState: %s", windowState->GetString());
+		blog(LOG_INFO, "obs-browser: state: restoring windowState: %s", windowState->GetString().ToString().c_str());
 
 		mainWindow()->restoreState(
 			QByteArray::fromStdString(base64_decode(windowState->GetString().ToString())));
@@ -949,7 +953,7 @@ void StreamElementsGlobalStateManager::UninstallPlugin()
 				NULL,
 				SW_SHOW);
 
-			BOOL bResult = (int)hInst > 32;
+			BOOL bResult = hInst > (HINSTANCE)32;
 
 			if (bResult) {
 				exec_success = true;

--- a/streamelements/StreamElementsHotkeyManager.cpp
+++ b/streamelements/StreamElementsHotkeyManager.cpp
@@ -163,7 +163,7 @@ bool StreamElementsHotkeyManager::SerializeHotkeyBindings(CefRefPtr<CefValue>& o
 	{
 		auto &keys = *static_cast<keys_t*>(data);
 
-		keys[obs_hotkey_binding_get_hotkey_id(binding)].emplace_back(
+		keys[obs_hotkey_binding_get_hotkey_id(binding)].push_back(
 			obs_hotkey_binding_get_key_combination(binding));
 
 		return true;
@@ -256,7 +256,7 @@ bool StreamElementsHotkeyManager::SerializeHotkeyBindings(CefRefPtr<CefValue>& o
 		break;
 		}
 
-		d.emplace_back(item);
+		d.push_back(item);
 
 		return true;
 	}, &data);
@@ -270,7 +270,7 @@ bool StreamElementsHotkeyManager::SerializeHotkeyBindings(CefRefPtr<CefValue>& o
 
 		CefRefPtr<CefDictionaryValue> itemDict = CefDictionaryValue::Create();
 
-		itemDict->SetInt("id", item.hotkey_id);
+		itemDict->SetInt("id", (int)item.hotkey_id);
 		itemDict->SetString("name", item.name);
 		itemDict->SetString("description", item.description);
 
@@ -286,7 +286,7 @@ bool StreamElementsHotkeyManager::SerializeHotkeyBindings(CefRefPtr<CefValue>& o
 		}
 
 		if (item.partner_hotkey_id != OBS_INVALID_HOTKEY_ID) {
-			itemDict->SetInt("partnerHotkeyBindingId", item.partner_hotkey_id);
+			itemDict->SetInt("partnerHotkeyBindingId", (int)item.partner_hotkey_id);
 		}
 
 		CefRefPtr<CefListValue> bindingComboList = CefListValue::Create();
@@ -328,6 +328,8 @@ bool StreamElementsHotkeyManager::DeserializeHotkeyBindings(CefRefPtr<CefValue> 
 
 void StreamElementsHotkeyManager::hotkeyTriggered(obs_hotkey_id id, obs_hotkey_t *hotkey, bool pressed)
 {
+	UNUSED_PARAMETER(hotkey);
+
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
 	if (m_registeredHotkeyDataString.count(id)) {
@@ -455,7 +457,7 @@ obs_hotkey_id StreamElementsHotkeyManager::DeserializeSingleHotkeyBinding(CefRef
 				obs_key_combination_t combination = DeserializeKeyCombination(triggersList->GetValue(index));
 
 				if (!obs_key_combination_is_empty(combination)) {
-					combinations.emplace_back(combination);
+					combinations.push_back(combination);
 				}
 			}
 		}

--- a/streamelements/StreamElementsMenuManager.cpp
+++ b/streamelements/StreamElementsMenuManager.cpp
@@ -76,7 +76,7 @@ void StreamElementsMenuManager::Update()
 				id.c_str());
 
 			if (info) {
-				widgets.emplace_back(info);
+				widgets.push_back(info);
 			}
 		}
 

--- a/streamelements/StreamElementsNetworkDialog.cpp
+++ b/streamelements/StreamElementsNetworkDialog.cpp
@@ -7,7 +7,7 @@
 
 #include <QCloseEvent>
 
-inline static std::string GetCommandLineOptionValue(const std::string key)
+inline std::string GetCommandLineOptionValue(const std::string key)
 {
 	QStringList args = QCoreApplication::instance()->arguments();
 
@@ -88,6 +88,9 @@ int StreamElementsNetworkDialog::DownloadFileAsyncXferProgressCallback(
 	curl_off_t ultotal,
 	curl_off_t ulnow)
 {
+	UNUSED_PARAMETER(ultotal);
+	UNUSED_PARAMETER(ulnow);
+
 	// Async progress tracking
 	local_context* task_context =
 		(local_context*)clientp;
@@ -136,6 +139,9 @@ int StreamElementsNetworkDialog::UploadFileAsyncXferProgressCallback(
 	curl_off_t ultotal,
 	curl_off_t ulnow)
 {
+	UNUSED_PARAMETER(ultotal);
+	UNUSED_PARAMETER(ulnow);
+
 	// Async progress tracking
 	local_context* task_context =
 		(local_context*)clientp;
@@ -156,6 +162,7 @@ int StreamElementsNetworkDialog::UploadFileAsyncXferProgressCallback(
 		return (int)CURLE_ABORTED_BY_CALLBACK;
 	}
 
+	/*
 	time_t now = time(&now);
 
 	time_t time_delta = now - task_context->last_progress_report_time;
@@ -164,7 +171,7 @@ int StreamElementsNetworkDialog::UploadFileAsyncXferProgressCallback(
 	if (ultotal > 0L) {
 		percent = (long)(ulnow * 100L / ultotal);
 	}
-	size_t percent_delta = percent - task_context->last_progress_report_percent;
+	//size_t percent_delta = percent - task_context->last_progress_report_percent;
 
 	// Show progress once per second
 	bool show = time_delta >= 1 && ultotal > 32768L;
@@ -182,7 +189,7 @@ int StreamElementsNetworkDialog::UploadFileAsyncXferProgressCallback(
 
 		task_context->last_progress_report_time = now;
 		task_context->last_progress_report_percent = percent;
-	}
+	}*/
 }
 
 void StreamElementsNetworkDialog::DownloadFileAsync(const char* localFilePath, const char* url, bool large_file, void(*callback)(bool, void*), void* param, const char* message)

--- a/streamelements/StreamElementsPerformanceHistoryTracker.cpp
+++ b/streamelements/StreamElementsPerformanceHistoryTracker.cpp
@@ -74,7 +74,7 @@ StreamElementsPerformanceHistoryTracker::StreamElementsPerformanceHistoryTracker
 				item.busySeconds = kernelRat + userRat - idleRat;
 
 				std::lock_guard<std::recursive_mutex> guard(m_mutex);
-				m_cpu_usage.emplace_back(item);
+				m_cpu_usage.push_back(item);
 
 				while (m_cpu_usage.size() > BUF_SIZE) {
 					m_cpu_usage.erase(m_cpu_usage.begin());
@@ -89,7 +89,7 @@ StreamElementsPerformanceHistoryTracker::StreamElementsPerformanceHistoryTracker
 			if (GlobalMemoryStatusEx(&mem)) {
 				std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-				m_memory_usage.emplace_back(mem);
+				m_memory_usage.push_back(mem);
 
 				while (m_memory_usage.size() > BUF_SIZE) {
 					m_memory_usage.erase(m_memory_usage.begin());

--- a/streamelements/StreamElementsReportIssueDialog.cpp
+++ b/streamelements/StreamElementsReportIssueDialog.cpp
@@ -302,7 +302,7 @@ void StreamElementsReportIssueDialog::accept()
 
 			DWORD nColorTableSize = 0;
 			if (nBitCount != 24) {
-				nColorTableSize = (1 << nBitCount) * sizeof(RGBQUAD);
+				nColorTableSize = (1ULL << nBitCount) * sizeof(RGBQUAD);
 			}
 			else {
 				nColorTableSize = 0;
@@ -313,7 +313,7 @@ void StreamElementsReportIssueDialog::accept()
 
 			if (nBitCount < 16)
 			{
-				int nBytesWritten = 0;
+				//int nBytesWritten = 0;
 				RGBQUAD *rgbTable = new RGBQUAD[nColorTableEntries * sizeof(RGBQUAD)];
 				//fill RGBQUAD table and write it in file
 				for (int i = 0; i < nColorTableEntries; ++i)
@@ -334,6 +334,8 @@ void StreamElementsReportIssueDialog::accept()
 			::DeleteObject(hBMP);
 			::DeleteObject(hBitmap);
 			delete[]lpBitmapInfoHeader;
+
+			return true;
 		};
 
 		std::string package_manifest = "generator=report_issue\nversion=3\n";
@@ -357,8 +359,8 @@ void StreamElementsReportIssueDialog::accept()
 			};
 
 			// Collect all files
-			for (auto& i : std::tr2::sys::recursive_directory_iterator(programDataPathBuf)) {
-				if (!std::tr2::sys::is_directory(i.path())) {
+			for (auto& i : std::experimental::filesystem::recursive_directory_iterator(programDataPathBuf)) {
+				if (!std::experimental::filesystem::is_directory(i.path())) {
 					std::wstring local_path = i.path().c_str();
 					std::wstring zip_path = local_path.substr(obsDataPath.size() + 1);
 
@@ -406,7 +408,7 @@ void StreamElementsReportIssueDialog::accept()
 
 			addFileToZip(item.first, item.second);
 
-			dialog.setProgress(0, total, count);
+			dialog.setProgress(0, (int)total, (int)count);
 		}
 
 		if (dialog.cancelled()) {
@@ -506,11 +508,11 @@ void StreamElementsReportIssueDialog::accept()
 			{
 				std::vector<std::string> lines;
 
-				lines.emplace_back("totalSeconds,busySeconds,idleSeconds");
+				lines.push_back("totalSeconds,busySeconds,idleSeconds");
 				for (auto item : cpuUsageHistory) {
 					sprintf(lineBuf, "%1.2Lf,%1.2Lf,%1.2Lf", item.totalSeconds, item.busySeconds, item.idleSeconds);
 
-					lines.emplace_back(lineBuf);
+					lines.push_back(lineBuf);
 				}
 
 				addLinesBufferToZip(lines, L"system\\usage_history_cpu.csv");
@@ -519,7 +521,7 @@ void StreamElementsReportIssueDialog::accept()
 			{
 				std::vector<std::string> lines;
 
-				lines.emplace_back("totalSeconds,memoryUsedPercentage");
+				lines.push_back("totalSeconds,memoryUsedPercentage");
 
 				size_t index = 0;
 				for (auto item : memoryUsageHistory) {
@@ -538,7 +540,7 @@ void StreamElementsReportIssueDialog::accept()
 						);
 					}
 
-					lines.emplace_back(lineBuf);
+					lines.push_back(lineBuf);
 
 					++index;
 				}

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -433,7 +433,7 @@ void SerializeAvailableInputSourceTypes(CefRefPtr<CefValue>& output)
 			uint32_t sourceCaps = obs_get_source_output_flags(sourceId);
 
 			// If source has video
-			if (sourceCaps & OBS_SOURCE_VIDEO == OBS_SOURCE_VIDEO)
+			if ((sourceCaps & OBS_SOURCE_VIDEO) == OBS_SOURCE_VIDEO)
 			{
 				// Create source response dictionary
 				CefRefPtr<CefDictionaryValue> dic = CefDictionaryValue::Create();
@@ -441,8 +441,8 @@ void SerializeAvailableInputSourceTypes(CefRefPtr<CefValue>& output)
 				// Set codec dictionary properties
 				dic->SetString("id", sourceId);
 				dic->SetString("name", obs_source_get_display_name(sourceId));
-				dic->SetBool("hasVideo", sourceCaps & OBS_SOURCE_VIDEO == OBS_SOURCE_VIDEO);
-				dic->SetBool("hasAudio", sourceCaps & OBS_SOURCE_AUDIO == OBS_SOURCE_AUDIO);
+				dic->SetBool("hasVideo", (sourceCaps & OBS_SOURCE_VIDEO) == OBS_SOURCE_VIDEO);
+				dic->SetBool("hasAudio", (sourceCaps & OBS_SOURCE_AUDIO) == OBS_SOURCE_AUDIO);
 
 				// Compare sourceId to known video capture devices
 				dic->SetBool("isVideoCaptureDevice",
@@ -916,7 +916,7 @@ std::string GetComputerSystemUniqueId()
 		REG_VALUE_NAME,
 		REG_SZ,
 		result.c_str(),
-		result.size());
+		(DWORD)result.size());
 
 	return result;
 }

--- a/streamelements/StreamElementsWidgetManager.hpp
+++ b/streamelements/StreamElementsWidgetManager.hpp
@@ -86,8 +86,7 @@ protected:
 
 private:
 	QMainWindow* m_parent;
-
-	std::stack<QWidget*> m_centralWidgetStack;
+	QWidget* m_nativeCentralWidget;
 
 	std::map<std::string, QDockWidget*> m_dockWidgets;
 	std::map<std::string, Qt::DockWidgetArea> m_dockWidgetAreas;

--- a/streamelements/StreamElementsWorkerManager.cpp
+++ b/streamelements/StreamElementsWorkerManager.cpp
@@ -6,7 +6,7 @@
 
 #include <include/cef_parser.h>		// CefParseJSON, CefWriteJSON
 
-static class BrowserTask : public CefTask {
+class BrowserTask : public CefTask {
 public:
 	std::function<void()> task;
 
@@ -170,7 +170,7 @@ void StreamElementsWorkerManager::GetIdentifiers(std::vector<std::string>& resul
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
 	for (auto it = m_items.begin(); it != m_items.end(); ++it) {
-		result.emplace_back(it->first);
+		result.push_back(it->first);
 	}
 }
 
@@ -233,7 +233,7 @@ bool StreamElementsWorkerManager::SerializeOne(std::string id, CefRefPtr<CefValu
 	return true;
 }
 
-std::string StreamElementsWorkerManager::DeserializeOne(CefRefPtr<CefValue>& input)
+std::string StreamElementsWorkerManager::DeserializeOne(CefRefPtr<CefValue> input)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 

--- a/streamelements/StreamElementsWorkerManager.hpp
+++ b/streamelements/StreamElementsWorkerManager.hpp
@@ -32,7 +32,7 @@ public:
 	void Deserialize(CefRefPtr<CefValue>& input);
 
 	bool SerializeOne(std::string id, CefRefPtr<CefValue>& output);
-	std::string DeserializeOne(CefRefPtr<CefValue>& input);
+	std::string DeserializeOne(CefRefPtr<CefValue> input);
 
 protected:
 	virtual void OnObsExit();


### PR DESCRIPTION
In an effort to eliminate crash at DestroyCentralWidget()
simplify central widget logic (remove the stack, allow only
one replacement for the native widget to exist), resolve
compiler warnings which are in the scope of obs-browser,
replace calls to std::vector::emplace_back() with calls
to the more suitable std::vector::push_back()