### PR TITLE
Init widget CEF browser on widget creation

### DIFF
--- a/streamelements/StreamElementsBrowserWidget.cpp
+++ b/streamelements/StreamElementsBrowserWidget.cpp
@@ -67,6 +67,10 @@ StreamElementsBrowserWidget::~StreamElementsBrowserWidget()
 
 void StreamElementsBrowserWidget::InitBrowserAsync()
 {
+	if (!!m_cef_browser.get()) {
+		return;
+	}
+
 	// Make sure InitBrowserAsyncInternal() runs in Qt UI thread
 	QMetaObject::invokeMethod(this, "InitBrowserAsyncInternal");
 }

--- a/streamelements/StreamElementsBrowserWidget.hpp
+++ b/streamelements/StreamElementsBrowserWidget.hpp
@@ -98,12 +98,24 @@ private:
 	cef_window_handle_t m_window_handle;
 	CefRefPtr<CefBrowser> m_cef_browser;
 
+private:
+	bool m_isWidgetInitialized = false;
+
 protected:
+	virtual bool event(QEvent* event) override
+	{
+		if (!m_isWidgetInitialized) {
+			InitBrowserAsync();
+
+			m_isWidgetInitialized = true;
+		}
+
+		return QWidget::event(event);
+	}
+
 	virtual void showEvent(QShowEvent* showEvent) override
 	{
 		QWidget::showEvent(showEvent);
-
-		InitBrowserAsync();
 
 		ShowBrowser();
 


### PR DESCRIPTION
Init on visibility delays loading of content until widget is visible.
This causes widgets which were previously hidden by the user to remain
dormant until they are made visible again, defeating listening and
reacting to external events, such as External Controller commands.