### PR TITLE
API 1.14: Current docking area of browser widget

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -547,8 +547,24 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		CefRefPtr<CefDictionaryValue> d = CefDictionaryValue::Create();
 		result->SetDictionary(d);
 
-		d->SetString("id", client->GetContainerId());
-		d->SetString("area", client->GetLocationArea());
+		std::string dockingArea = "none";
+		std::string id = client->GetContainerId();
+
+		if (id.size()) {
+			StreamElementsBrowserWidgetManager::DockBrowserWidgetInfo* info =
+				StreamElementsGlobalStateManager::GetInstance()
+					->GetWidgetManager()
+					->GetDockBrowserWidgetInfo(id.c_str());
+
+			if (info) {
+				dockingArea = info->m_dockingArea;
+
+				delete info;
+			}
+		}
+
+		d->SetString("id", id.c_str());
+		d->SetString("dockingArea", dockingArea.c_str());
 		d->SetString("url", browser->GetMainFrame()->GetURL().ToString());
 		d->SetString("theme", GetCurrentThemeName());
 	API_HANDLER_END();

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 13
+#define HOST_API_VERSION_MINOR 14
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
# Feature
* Support detecting current docking area of browser widget

# Changes to data structures
ContainerInfo (`getCurrentContainerProperties` API call result)
* Remove inconsistent 'area' property
* Add 'dockingArea' property
