### PR TITLE
obs-browser: flush panel cookie store on exit

### DIFF
--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -13,6 +13,8 @@ extern bool QueueCEFTask(std::function<void()> task);
 extern "C" void obs_browser_initialize(void);
 extern os_event_t *cef_started_event;
 
+void register_cookie_manager(CefRefPtr<CefCookieManager> cm);
+
 std::mutex                      popup_whitelist_mutex;
 std::vector<PopupWhitelistInfo> popup_whitelist;
 std::vector<PopupWhitelistInfo> forced_popups;
@@ -82,6 +84,8 @@ struct QCefCookieManagerInternal : QCefCookieManager {
 				nullptr);
 		if (!cm)
 			throw "Failed to create cookie manager";
+
+		register_cookie_manager(cm);
 
 		rch = new QCefRequestContextHandler(cm);
 


### PR DESCRIPTION
If cookie store is not flushed, state might become inconsistent:
reading from the cookies file will become impossible.
No errors will be returned, yet no information will be available,
and no information will be stored: the cookie manager will appear to be
empty at all times and the `Cookies` file modified date will not update
moving forward.

This will result, for example, in Twitch chat window re-opening for
users which connected their Twitch account, but not having the
`auth-token` cookie available: once the user will try to send a
message to the chat, they will be redirected to Twitch login screen.