### PR TITLE
obs-browser: set machine config via EXE cfg writer

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -814,11 +814,12 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 				std::string quality = d->GetString("quality");
 				std::string manifestUrl = d->GetString("manifestUrl");
 
-				WriteProductEnvironmentConfigurationString(
-					"Quality", quality.c_str());
+				bool writeResult = WriteProductEnvironmentConfigurationStrings({
+						{ "", "Quality", quality },
+						{ "", "ManifestUrl", manifestUrl }
+					});
 
-				WriteProductEnvironmentConfigurationString(
-					"ManifestUrl", manifestUrl.c_str());
+				result->SetBool(writeResult);
 			}
 		}
 	API_HANDLER_END()

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <cstdio>
 #include <cstdarg>
+#include <vector>
 
 #include <functional>
 
@@ -92,5 +93,17 @@ std::string GetComputerSystemUniqueId();
 
 /* ========================================================= */
 
+struct streamelements_env_update_request {
+public:
+	std::string product;
+	std::string key;
+	std::string value;
+};
+
+typedef std::vector<streamelements_env_update_request> streamelements_env_update_requests;
+
 std::string ReadProductEnvironmentConfigurationString(const char* key);
 bool WriteProductEnvironmentConfigurationString(const char* key, const char* value);
+bool WriteProductEnvironmentConfigurationStrings(streamelements_env_update_requests requests);
+bool WriteEnvironmentConfigStrings(streamelements_env_update_requests requests);
+bool WriteEnvironmentConfigString(const char* regValueName, const char* regValue, const char* productName);


### PR DESCRIPTION
* UAC will not permit setting machine-level configuration via
  direct Win32 API calls in most cases

* Use external executable with elevated privileges to set machine-level
  configuration (`obs-streamelements-set-machine-config.exe` in the
  plugin folder).