### PR TITLE
obs-browser: revert to building master branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,10 +28,6 @@ install:
 
     cd /d c:\local\obs-studio
 
-    git fetch origin 23.0.2
-
-    git checkout 23.0.2
-
     git submodule update --init --recursive
 
     rd /s /q c:\local\obs-studio\plugins\obs-browser


### PR DESCRIPTION
* Breaking change was resolved in `obs-studio` repo

* Revert back to pulling `master` branch so we can spot issues as
  they happen