### PR TITLE
obs-browser: resolve external refFiles issues

### DIFF
--- a/streamelements/StreamElementsExternalSceneDataProvider.hpp
+++ b/streamelements/StreamElementsExternalSceneDataProvider.hpp
@@ -34,7 +34,7 @@ protected:
 
 	struct scene_collection_content_t : public scene_collection_t {
 		std::vector<scene_collection_file_content_t> metadataFiles;
-		std::vector<std::string> referencedFiles;
+		std::vector<std::wstring> referencedFiles;
 	};
 
 	virtual bool GetSceneCollections(
@@ -100,14 +100,25 @@ public:
 			d->SetList("metadataFiles", list);
 		}
 
-		{
+		{ 
 			CefRefPtr<CefListValue> list = CefListValue::Create();
 
+			std::map<std::wstring, std::string> uniqueReferencedFiles;
+
 			for (auto file : collection.referencedFiles) {
+				if (uniqueReferencedFiles.count(file)) {
+					continue;
+				}
+
+				uniqueReferencedFiles[file] =
+					CreateSessionSignedAbsolutePathURL(file);
+			}
+
+			for (auto kv : uniqueReferencedFiles) {
 				CefRefPtr<CefDictionaryValue> item = CefDictionaryValue::Create();
 
-				item->SetString("path", file.c_str());
-				item->SetString("url", CreateSessionSignedAbsolutePathURL(file));
+				item->SetString("path", kv.first.c_str());
+				item->SetString("url", kv.second.c_str());
 
 				list->SetDictionary(list->GetSize(), item);
 			}

--- a/streamelements/StreamElementsExternalSceneDataProviderSlobsClient.cpp
+++ b/streamelements/StreamElementsExternalSceneDataProviderSlobsClient.cpp
@@ -86,14 +86,11 @@ bool StreamElementsExternalSceneDataProviderSlobsClient::GetSceneCollections(
 	return success;
 }
 
-static void dumpPaths(CefRefPtr<CefValue> parent, std::vector<std::string>& paths)
+static void dumpPaths(CefRefPtr<CefValue> parent, std::vector<std::wstring>& paths)
 {
 	if (parent->GetType() == VTYPE_STRING) {
-		std::wstring_convert<std::codecvt_utf8<wchar_t>> myconv;
-
-		std::string candidate =
-			myconv.to_bytes(
-				parent->GetString().ToWString());
+		std::wstring candidate =
+			parent->GetString().ToWString();
 
 		if (std::experimental::filesystem::is_regular_file(candidate)) {
 			paths.push_back(candidate);
@@ -192,15 +189,17 @@ bool StreamElementsExternalSceneDataProviderSlobsClient::GetSceneCollection(
 
 		bfree(scene_collection_content);
 
+		std::wstring_convert<std::codecvt_utf8<wchar_t>> myconv;
+
 		CefRefPtr<CefValue> root =
 			CefParseJSON(
-				meta_scene_collection.content.c_str(),
+				myconv.from_bytes(meta_scene_collection.content).c_str(),
 				JSON_PARSER_ALLOW_TRAILING_COMMAS);
 
 		if (root->GetType() != VTYPE_NULL && root->GetType() != VTYPE_INVALID) {
 			success = true;
 
-			std::vector<std::string> paths;
+			std::vector<std::wstring> paths;
 
 			dumpPaths(root, paths);
 

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -1179,19 +1179,24 @@ bool VerifySessionMessageSignature(std::string& message, std::string& signature)
 	return digest == signature;
 }
 
-std::string CreateSessionSignedAbsolutePathURL(std::string path)
+std::string CreateSessionSignedAbsolutePathURL(std::wstring path)
 {
-	CefURLParts parts;
+ 	CefURLParts parts;
 
 	CefString(&parts.scheme) = "https";
 	CefString(&parts.host) = "absolute";
-	CefString(&parts.path) = std::string("/") + path;
+	CefString(&parts.path) = std::wstring(L"/") + path;
 
 	CefString url;
 	CefCreateURL(parts, url);
 	CefParseURL(url, parts);
 
-	std::string message = CefString(&parts.path).ToString().erase(0, 1);
+	std::string message = CefString(&parts.path).ToString();
+
+	message = CefURIDecode(message, true, cef_uri_unescape_rule_t::UU_SPACES);
+	message = CefURIDecode(message, true, cef_uri_unescape_rule_t::UU_URL_SPECIAL_CHARS_EXCEPT_PATH_SEPARATORS);
+
+	message = message.erase(0, 1);
 
 	return url.ToString() + std::string("?digest=") +
 		CreateSessionMessageSignature(message);
@@ -1205,7 +1210,7 @@ bool VerifySessionSignedAbsolutePathURL(std::string url, std::string& path)
 		return false;
 	}
 	else {
-		path = CefString(&parts.path);
+		path = CefString(&parts.path).ToString();
 
 		path = CefURIDecode(path, true, cef_uri_unescape_rule_t::UU_SPACES);
 		path = CefURIDecode(path, true, cef_uri_unescape_rule_t::UU_URL_SPECIAL_CHARS_EXCEPT_PATH_SEPARATORS);

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -115,5 +115,5 @@ bool ParseQueryString(std::string input, std::map<std::string, std::string>& res
 std::string CreateSHA256Digest(std::string& input);
 std::string CreateSessionMessageSignature(std::string& message);
 bool VerifySessionMessageSignature(std::string& message, std::string& signature);
-std::string CreateSessionSignedAbsolutePathURL(std::string path);
+std::string CreateSessionSignedAbsolutePathURL(std::wstring path);
 bool VerifySessionSignedAbsolutePathURL(std::string url, std::string& path);


### PR DESCRIPTION
* External scene data referencedFiles with spaces in local path were
  returning URLs with wrong digital signatures.

* Correctly interpret unicode scene data referencedFiles paths.

* Remove duplicate referencedFiles entries.