### PR TITLE
obs-browser: handle corrupt SLOBS JSON files

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -871,7 +871,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		if (args->GetSize()) {
 			StreamElementsGlobalStateManager::GetInstance()->
 				GetExternalSceneDataProviderManager()->
-				SerializeProviderSceneColletions(args->GetValue(0), result);
+				SerializeProviderSceneCollections(args->GetValue(0), result);
 		}
 	API_HANDLER_END()
 

--- a/streamelements/StreamElementsExternalSceneDataProviderManager.hpp
+++ b/streamelements/StreamElementsExternalSceneDataProviderManager.hpp
@@ -33,7 +33,7 @@ public:
 		result->SetList(list);
 	}
 
-	bool SerializeProviderSceneColletions(
+	bool SerializeProviderSceneCollections(
 		CefRefPtr<CefValue> input,
 		CefRefPtr<CefValue> result)
 	{


### PR DESCRIPTION
* In case SLOBS JSON files are corrupt, log and return proper failure
  result instead of crashing.

* Log failures to decode UTF-8 SLOBS file content.