### PR TITLE
obs-browser: prevent external controller deadlock

### DIFF
--- a/streamelements/StreamElementsControllerServer.cpp
+++ b/streamelements/StreamElementsControllerServer.cpp
@@ -8,8 +8,9 @@ static const char* SOURCE_ADDR = "";
 StreamElementsControllerServer::StreamElementsControllerServer(StreamElementsMessageBus* bus) :
 	m_bus(bus)
 {
-	auto msgReceiver = [this](const char* const buffer, const size_t) {
-		std::string str(buffer);
+	auto msgReceiver = [this](const char* const buffer, const size_t length) {
+		std::string str = "";
+		str.append(buffer, length);
 
 		OnMsgReceivedInternal(str);
 	};

--- a/streamelements/deps/server/NamedPipesServerClientHandler.hpp
+++ b/streamelements/deps/server/NamedPipesServerClientHandler.hpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <thread>
 #include <mutex>
+#include <vector>
+#include "streamelements/deps/moodycamel/blockingconcurrentqueue.h"
 
 // Single named pipes client handler.
 //
@@ -27,12 +29,17 @@ public:
 	bool WriteMessage(const char* const buffer, size_t length);
 
 private:
+	void CallbackThreadProc();
 	void ThreadProc();
 
 private:
 	HANDLE m_hPipe;
 	std::thread m_thread;
+	std::thread m_callback_thread;
 	msg_handler_t m_msgHandler;
 	std::recursive_mutex m_mutex;
+
+	moodycamel::BlockingConcurrentQueue<std::vector<char>> m_writeQueue;
+	moodycamel::BlockingConcurrentQueue<std::vector<char>> m_readQueue;
 };
 


### PR DESCRIPTION
* Add read queue and write queue to named pipe client handler
* Perform named pipe read & write operations in a single thread
* Write from queue, read to queue
* Perform read callbacks in a separate thread