### PR TITLE
obs-browser: API 1.17: add getStreamingStatus

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -891,6 +891,14 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		}
 	API_HANDLER_END()
 
+	API_HANDLER_BEGIN("getStreamingStatus")
+		CefRefPtr<CefDictionaryValue> d = CefDictionaryValue::Create();
+
+		d->SetBool("isStreamingActive", obs_frontend_streaming_active());
+
+		result->SetDictionary(d);
+	API_HANDLER_END()
+
 	API_HANDLER_BEGIN("crashProgram")
 		// Crash
 		*((int*)nullptr) = 12345; // exception

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 16
+#define HOST_API_VERSION_MINOR 17
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
* Add getStreamingStatus API call to retrieve current streaming status

* Used to determine whether OBS is currently streaming or not