### PR TITLE
obs-browser: start/stop stream handler singleton

### DIFF
--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -328,7 +328,7 @@ void StreamElementsGlobalStateManager::Initialize(QMainWindow* obs_main_window)
 		context->self->m_hotkeyManager = new StreamElementsHotkeyManager();
 		context->self->m_performanceHistoryTracker = new StreamElementsPerformanceHistoryTracker();
 		context->self->m_externalSceneDataProviderManager = new StreamElementsExternalSceneDataProviderManager();
-		context->self->m_nativeObsControlsManager = new StreamElementsNativeOBSControlsManager(context->obs_main_window);
+		context->self->m_nativeObsControlsManager = StreamElementsNativeOBSControlsManager::GetInstance();
 
 		{
 			// Set up "Live Support" button
@@ -502,7 +502,7 @@ void StreamElementsGlobalStateManager::Shutdown()
 		delete self->m_localWebFilesServer;
 		delete self->m_externalSceneDataProviderManager;
 		delete self->m_httpClient;
-		delete self->m_nativeObsControlsManager;
+		// delete self->m_nativeObsControlsManager; // Singleton
 	}, this);
 
 	m_initialized = false;

--- a/streamelements/StreamElementsNativeOBSControlsManager.cpp
+++ b/streamelements/StreamElementsNativeOBSControlsManager.cpp
@@ -9,6 +9,20 @@
 #include <obs-module.h>
 #include <obs-frontend-api.h>
 
+StreamElementsNativeOBSControlsManager* StreamElementsNativeOBSControlsManager::GetInstance()
+{
+	static StreamElementsNativeOBSControlsManager* s_instance = nullptr;
+	static std::mutex s_mutex;
+
+	if (s_instance == nullptr) {
+		std::lock_guard<std::mutex> guard(s_mutex);
+
+		s_instance = new StreamElementsNativeOBSControlsManager((QMainWindow*) obs_frontend_get_main_window());
+	}
+
+	return s_instance;
+}
+
 StreamElementsNativeOBSControlsManager::StreamElementsNativeOBSControlsManager(QMainWindow* mainWindow) :
 	m_mainWindow(mainWindow)
 {

--- a/streamelements/StreamElementsNativeOBSControlsManager.hpp
+++ b/streamelements/StreamElementsNativeOBSControlsManager.hpp
@@ -24,6 +24,9 @@ public:
 	};
 
 public:
+	static StreamElementsNativeOBSControlsManager* GetInstance();
+
+private:
 	StreamElementsNativeOBSControlsManager(QMainWindow* mainWindow);
 	virtual ~StreamElementsNativeOBSControlsManager();
 


### PR DESCRIPTION
Turn `StreamElementsNativeOBSControlsManager` into a singleton class
with global lifespan.

The reason for this is that there is no way to undo a call to
`obs_hotkey_set_callback_routing_func`, therefor we can not provide a
proper destructor for `StreamElementsNativeOBSControlsManager`.