### PR TITLE
obs-browser: pop-up dialog inherits always-on-top

### DIFF
--- a/streamelements/StreamElementsBrowserDialog.cpp
+++ b/streamelements/StreamElementsBrowserDialog.cpp
@@ -69,6 +69,10 @@ StreamElementsBrowserDialog::StreamElementsBrowserDialog(QWidget* parent, std::s
 		(windowFlags() | Qt::CustomizeWindowHint)
 		& ~Qt::WindowContextHelpButtonHint
 		));
+
+	if (!!parent && IsAlwaysOnTop(parent)) {
+		SetAlwaysOnTop(this, true);
+	}
 }
 
 StreamElementsBrowserDialog::~StreamElementsBrowserDialog()

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -1427,3 +1427,34 @@ bool VerifySessionSignedAbsolutePathURL(std::string url, std::string& path)
 		}
 	}
 }
+
+/* ========================================================= */
+
+bool IsAlwaysOnTop(QWidget* window)
+{
+#ifdef WIN32
+	DWORD exStyle = GetWindowLong((HWND)window->winId(), GWL_EXSTYLE);
+	return (exStyle & WS_EX_TOPMOST) != 0;
+#else
+	return (window->windowFlags() & Qt::WindowStaysOnTopHint) != 0;
+#endif
+}
+
+void SetAlwaysOnTop(QWidget* window, bool enable)
+{
+#ifdef WIN32
+	HWND hwnd = (HWND)window->winId();
+	SetWindowPos(hwnd, enable ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
+		SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+#else
+	Qt::WindowFlags flags = window->windowFlags();
+
+	if (enable)
+		flags |= Qt::WindowStaysOnTopHint;
+	else
+		flags &= ~Qt::WindowStaysOnTopHint;
+
+	window->setWindowFlags(flags);
+	window->show();
+#endif
+}

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -26,6 +26,7 @@
 #include <QFile>
 #include <QTextStream>
 #include <QString>
+#include <QWidget>
 
 template<typename ... Args>
 std::string FormatString(const char* format, ...)
@@ -145,3 +146,8 @@ std::string CreateSessionMessageSignature(std::string& message);
 bool VerifySessionMessageSignature(std::string& message, std::string& signature);
 std::string CreateSessionSignedAbsolutePathURL(std::wstring path);
 bool VerifySessionSignedAbsolutePathURL(std::string url, std::string& path);
+
+/* ========================================================= */
+
+bool IsAlwaysOnTop(QWidget* window);
+void SetAlwaysOnTop(QWidget* window, bool enable);


### PR DESCRIPTION
* Inherit always-on-top state set on OBS main window when opening a
  modal dialog using `showModalDialog` to avoid the pop-up dialog
  being hidden by an always-on-top main window