### PR TITLE
obs-browser: API 1.19: add getEncodingSettings

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -551,6 +551,10 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		}
 	API_HANDLER_END();
 
+	API_HANDLER_BEGIN("getEncodingSettings");
+		StreamElementsGlobalStateManager::GetInstance()->GetOutputSettingsManager()->GetEncodingSettings(result);
+	API_HANDLER_END();
+
 	API_HANDLER_BEGIN("setEncodingSettings");
 		if (args->GetSize()) {
 			result->SetBool(

--- a/streamelements/StreamElementsOutputSettingsManager.hpp
+++ b/streamelements/StreamElementsOutputSettingsManager.hpp
@@ -11,8 +11,11 @@ public:
 
 public:
 	void GetAvailableEncoders(CefRefPtr<CefValue>& result, obs_encoder_type* encoder_type = nullptr);
+
 	bool SetStreamingSettings(CefRefPtr<CefValue> input);
+
 	bool SetEncodingSettings(CefRefPtr<CefValue> input);
+	bool GetEncodingSettings(CefRefPtr<CefValue>& output);
 
 private:
 	void StopAllOutputs();

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 18
+#define HOST_API_VERSION_MINOR 19
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
* Add getEncodingSettings API call to retrieve CODEC, video frame size,
  bitrate, FPS and other encoder settings.