### PR TITLE
obs-browser: remove USE_QT_LOOP check

### DIFF
--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -238,9 +238,7 @@ QCefWidgetInternal::~QCefWidgetInternal()
 			 * to lock up */
 			int code = ETIMEDOUT;
 			while (code == ETIMEDOUT) {
-#if USE_QT_LOOP
 				QCoreApplication::processEvents();
-#endif
 				code = os_event_timedwait(finishedEvent, 5);
 			}
 		}


### PR DESCRIPTION
* Fix issue where browser panel would freeze on Twitch service connect
  through OBS studio