### PR TITLE
obs-browser: enable API for overlay editor pop-up

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -140,7 +140,7 @@ static bool on_streamelements_edit_overlay_click(obs_properties_t *props,
 		CefRefPtr<CefDictionaryValue> d = CefDictionaryValue::Create();
 
 		d->SetString("url", editor_url);
-		d->SetBool("enableHostApi", false);
+		d->SetBool("enableHostApi", true);
 		d->SetString("executeJavaScriptOnLoad", "");
 
 		root->SetDictionary(d);


### PR DESCRIPTION
The overlay editor should behavior differently when open in OBS.Live
context. Enabling the API allows the overlay editor code to detect
whether it's running in OBS.Live context.