### PR TITLE
obs-browser: override hw accel rendering issue

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -172,7 +172,18 @@ bool BrowserClient::GetViewRect(
 #endif
 	}
 
+#if ENABLE_WASHIDDEN_RESIZE_HACK
+	if (browser_visibility_resize_hack_state == 0) {
+		rect.Set(0, 0, source->width, source->height);
+	} else {
+		rect.Set(0, 0, source->width, source->height + 1);
+
+		++browser_visibility_resize_hack_state;
+	}
+#else
 	rect.Set(0, 0, source->width, source->height);
+#endif
+
 #if CHROME_VERSION_BUILD >= 3578
 	return;
 #else

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -59,6 +59,9 @@ public:
 	ChannelLayout channel_layout;
 	int frames_per_buffer;
 #endif
+#if ENABLE_WASHIDDEN_RESIZE_HACK
+	int browser_visibility_resize_hack_state = 0; // 0 - inactive, 1 - armed, 2+ - ready to disarm
+#endif
 
 	inline BrowserClient(BrowserSource *bs_, bool sharing_avail,
 			     bool reroute_audio_)


### PR DESCRIPTION
CEF 3729 and 3770 have a nasty rendering bug when
CefBrowserHost::WasHidden() is used to indicate page
visibility and (mostly) when there are 5+ browser
sources (in all scenes).

To overcome this issue, we employ a hack suggested here:
https://bitbucket.org/chromiumembedded/cef/issues/2483/osr-invalidate-does-not-generate-frame
Namely: change the size of the browser frame, call
CefBrowserHost::WasResized() to indicate size change and
later change the size of the browser back again, followed
by another call to CefBrowserHost::WasResized().

This sometimes leaves video players in paused state, therefor
we follow up with calling CefBrowserHost::WasHidden(false),
CefBrowserHost::WasHidden(true) and CefBrowserHost::WasHidden(false)
again. This seems to release whatever was blocking video rendering.

This was tested only with CEF 3729 release branch with patches applied
(see below).

Other approaches to overriding this bug (simulating
the Page Visibility API and avoiding calling
WasHidden() at all yielded sub-par performance:
browser sources which are not supposed to be visible
were still decoding and rendering video in the
background, consuming CPU & GPU resources.

The current known issue with this is that web
pages which use the Page Visibility API, will get
multiple events when the browser source becomes
visible (i.e. instead of "shown", the web page will
have the following sequence of events: "shown",
"hidden", "shown").

For this hack to work, one must build CEF with the
following patches:

Fix gclient_util after depot_tools changes (fixes issue #2736)
https://bitbucket.org/chromiumembedded/cef/commits/16a67c450724f60708b8b6af32bd7d547392c485

Fix OSR use_external_begin_frame support and update VSync setters (fixes issue #2618):
https://bitbucket.org/chromiumembedded/cef/commits/5623338662e9afe558c12f3e4439a3c8da701f1b

Remove CHECK for size change:
https://chromium-review.googlesource.com/c/chromium/src/+/1792459/2/content/browser/renderer_host/render_widget_host_impl.cc