### PR TITLE
obs-browser: shorten backup content paths

### DIFF
--- a/streamelements/StreamElementsBackupManager.cpp
+++ b/streamelements/StreamElementsBackupManager.cpp
@@ -283,9 +283,9 @@ ScanForFileReferencesToBackup(zip_t *zip, CefRefPtr<CefValue> &node,
 		if (os_file_exists(path.c_str())) {
 			if (!filesMap.count(path)) {
 				std::string fileName =
-					GetUniqueFileNameFromPath(path, 96);
+					GetUniqueFileNameFromPath(path, 48);
 				std::string zipPath =
-					"plugin_config/obs-browser/streamelements_restored_files/" +
+					"obslive_restored_files/" +
 					timestamp + "/" + fileName;
 
 				if (!AddFileToZip(zip, path, zipPath))
@@ -555,8 +555,7 @@ void StreamElementsBackupManager::CreateLocalBackupPackage(
 	time_t time = std::time(nullptr);
 	std::strftime(timestampBuf, sizeof(timestampBuf), "%Y%m%d%H%M%S",
 		      std::localtime(&time));
-	std::string timestamp = timestampBuf + std::string("-") +
-				CreateGloballyUniqueIdString();
+	std::string timestamp = timestampBuf;
 
 	for (auto collection : requestCollections) {
 		if (!AddCollectionToZip(zip, basePath, collection,
@@ -837,7 +836,7 @@ void StreamElementsBackupManager::RestoreBackupPackageContent(
 							.c_str(),
 						_O_WRONLY | _O_CREAT |
 							_O_BINARY,
-						_S_IWRITE /*_S_IREAD | _S_IWRITE*/);
+						_S_IREAD | _S_IWRITE);
 
 					if (-1 == context.handle) {
 						success = false;

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -1854,10 +1854,7 @@ std::string GetUniqueFileNameFromPath(std::string path, size_t maxLength)
 
 std::string GetFolderPathFromFilePath(std::string filePath)
 {
-	char buf[MAX_PATH + 1];
-	os_get_abs_path(filePath.c_str(), buf, sizeof(buf));
-
-	std::string path(buf);
+	std::string path(filePath);
 
 	std::transform(path.begin(), path.end(), path.begin(), [](char ch) {
 		if (ch == '\\')
@@ -1868,7 +1865,10 @@ std::string GetFolderPathFromFilePath(std::string filePath)
 
 	size_t pos = path.find_last_of('/');
 
-	return path.substr(0, pos);
+	if (pos > 0)
+		return path.substr(0, pos);
+	else
+		return ".";
 }
 
 bool ReadListOfObsSceneCollections(std::map<std::string, std::string> &output)


### PR DESCRIPTION
* Long paths resulted in restore failures

* Shorten generated paths to overcome this obstacle