### PR TITLE
obs-browser: OBS.Live: API 1.23: widgets editing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ set(obs-browser_SOURCES
 	streamelements/StreamElementsProfilesManager.cpp
 	streamelements/StreamElementsBackupManager.cpp
 	streamelements/StreamElementsCleanupManager.cpp
+	streamelements/StreamElementsPreviewManager.cpp
 	streamelements/deps/zip/zip.c
 	streamelements/deps/server/NamedPipesServer.cpp
 	streamelements/deps/server/NamedPipesServerClientHandler.cpp
@@ -230,6 +231,7 @@ set(obs-browser_HEADERS
 	streamelements/StreamElementsProfilesManager.hpp
 	streamelements/StreamElementsBackupManager.hpp
 	streamelements/StreamElementsCleanupManager.hpp
+	streamelements/StreamElementsPreviewManager.hpp
 	streamelements/deps/zip/zip.h
 	streamelements/deps/zip/miniz.h
 	streamelements/deps/moodycamel/concurrentqueue.h

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -63,6 +63,13 @@ static void SendBrowserVisibility(CefRefPtr<CefBrowser> browser, bool isVisible)
 BrowserSource::BrowserSource(obs_data_t *, obs_source_t *source_)
 	: source(source_)
 {
+	{
+		auto handler = obs_source_get_signal_handler(source_);
+		signal_handler_add(
+			handler,
+			"void streamelements_update_settings(ptr source)");
+	}
+
 	/* defer update */
 	obs_source_update(source, nullptr);
 
@@ -459,6 +466,21 @@ void BrowserSource::Update(obs_data_t *settings)
 	ClearAudioStreams();
 	if (!shutdown_on_invisible || obs_source_showing(source))
 		create_browser = true;
+
+	if (!first_update) {
+		calldata_t cd;
+
+		calldata_init(&cd);
+
+		calldata_set_ptr(&cd, "source", source);
+
+		auto handler = obs_source_get_signal_handler(source);
+
+		signal_handler_signal(handler, "streamelements_update_settings",
+				      &cd);
+
+		calldata_free(&cd);
+	}
 
 	first_update = false;
 }

--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -469,7 +469,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 	}
 	API_HANDLER_END();
 
-	API_HANDLER_BEGIN("toggleDockingWidgetFloatingById")
+	API_HANDLER_BEGIN("toggleDockingWidgetFloatingById");
 	{
 		if (args->GetSize() && args->GetType(0) == VTYPE_STRING) {
 			result->SetBool(
@@ -489,9 +489,9 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 			}
 		}
 	}
-	API_HANDLER_END()
+	API_HANDLER_END();
 
-	API_HANDLER_BEGIN("setDockingWidgetDimensionsById")
+	API_HANDLER_BEGIN("setDockingWidgetDimensionsById");
 	{
 		if (args->GetSize() >= 2 && args->GetType(0) == VTYPE_STRING &&
 		    args->GetType(1) == VTYPE_DICTIONARY) {
@@ -529,9 +529,9 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 			}
 		}
 	}
-	API_HANDLER_END()
+	API_HANDLER_END();
 
-	API_HANDLER_BEGIN("setDockingWidgetPositionById")
+	API_HANDLER_BEGIN("setDockingWidgetPositionById");
 	{
 		if (args->GetSize() >= 2 && args->GetType(0) == VTYPE_STRING &&
 		    args->GetType(1) == VTYPE_DICTIONARY) {
@@ -569,7 +569,74 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 			}
 		}
 	}
-	API_HANDLER_END()
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("setDockingWidgetUrlById");
+	{
+		if (args->GetSize() >= 2 && args->GetType(0) == VTYPE_STRING &&
+		    args->GetType(1) == VTYPE_STRING) {
+			result->SetBool(
+				StreamElementsGlobalStateManager::GetInstance()
+					->GetWidgetManager()
+					->SetWidgetUrlById(args->GetString(0)
+								   .ToString()
+								   .c_str(),
+							   args->GetString(1)
+								   .ToString()
+								   .c_str()));
+
+			if (result->GetBool()) {
+				StreamElementsGlobalStateManager::GetInstance()
+					->GetMenuManager()
+					->Update();
+				StreamElementsGlobalStateManager::GetInstance()
+					->PersistState();
+			}
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("showDockingWidgetById");
+	{
+		if (args->GetSize() >= 1 && args->GetType(0) == VTYPE_STRING) {
+			result->SetBool(
+				StreamElementsGlobalStateManager::GetInstance()
+					->GetWidgetManager()
+					->ShowDockWidgetById(args->GetString(0)
+								 .ToString()
+								 .c_str()));
+
+			if (result->GetBool()) {
+				StreamElementsGlobalStateManager::GetInstance()
+					->GetMenuManager()
+					->Update();
+				StreamElementsGlobalStateManager::GetInstance()
+					->PersistState();
+			}
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("hideDockingWidgetById");
+	{
+		if (args->GetSize() >= 1 && args->GetType(0) == VTYPE_STRING) {
+			result->SetBool(
+				StreamElementsGlobalStateManager::GetInstance()
+					->GetWidgetManager()
+					->HideDockWidgetById(args->GetString(0)
+								 .ToString()
+								 .c_str()));
+
+			if (result->GetBool()) {
+				StreamElementsGlobalStateManager::GetInstance()
+					->GetMenuManager()
+					->Update();
+				StreamElementsGlobalStateManager::GetInstance()
+					->PersistState();
+			}
+		}
+	}
+	API_HANDLER_END();
 
 	API_HANDLER_BEGIN("beginOnBoarding");
 	{
@@ -979,9 +1046,11 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 				->NotifyAllMessageListeners(
 					StreamElementsMessageBus::DEST_ALL_LOCAL,
 					StreamElementsMessageBus::SOURCE_WEB,
+					browser ?
 					browser->GetMainFrame()
 						->GetURL()
-						.ToString(),
+							  .ToString()
+						: "urn:streamelements:internal",
 					message);
 
 			result->SetBool(true);
@@ -997,6 +1066,12 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 
 			if (d->HasKey("name") &&
 			    d->GetType("name") == VTYPE_STRING) {
+				std::string sourceUrl =
+					browser ? browser->GetMainFrame()
+							  ->GetURL()
+							  .ToString()
+						: "urn:streamelements:internal";
+
 				StreamElementsMessageBus::GetInstance()
 					->NotifyAllLocalEventListeners(
 						StreamElementsMessageBus::
@@ -1005,9 +1080,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 								DEST_BROWSER_SOURCE,
 						StreamElementsMessageBus::
 							SOURCE_WEB,
-						browser->GetMainFrame()
-							->GetURL()
-							.ToString(),
+						sourceUrl,
 						"hostEventReceived",
 						args->GetValue(0));
 
@@ -1017,9 +1090,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 							DEST_ALL_EXTERNAL,
 						StreamElementsMessageBus::
 							SOURCE_WEB,
-						browser->GetMainFrame()
-							->GetURL()
-							.ToString(),
+						sourceUrl,
 						d->GetString("name"),
 						d->GetValue("data"));
 

--- a/streamelements/StreamElementsBrowserWidget.cpp
+++ b/streamelements/StreamElementsBrowserWidget.cpp
@@ -316,10 +316,14 @@ void StreamElementsBrowserWidget::BrowserReload(bool ignoreCache)
 	}
 }
 
-void StreamElementsBrowserWidget::BrowserLoadInitialPage()
+void StreamElementsBrowserWidget::BrowserLoadInitialPage(const char *const url)
 {
 	if (!m_cef_browser.get()) {
 		return;
+	}
+
+	if (url) {
+		m_url = url;
 	}
 
 	m_cef_browser->GetMainFrame()->LoadURL(GetInitialPageURLInternal());

--- a/streamelements/StreamElementsBrowserWidget.hpp
+++ b/streamelements/StreamElementsBrowserWidget.hpp
@@ -76,7 +76,7 @@ public:
 	void BrowserHistoryGoBack();
 	void BrowserHistoryGoForward();
 	void BrowserReload(bool ignoreCache);
-	void BrowserLoadInitialPage();
+	void BrowserLoadInitialPage(const char* const url = nullptr);
 
 private:
 	///

--- a/streamelements/StreamElementsBrowserWidgetManager.cpp
+++ b/streamelements/StreamElementsBrowserWidgetManager.cpp
@@ -4,13 +4,13 @@
 #include "StreamElementsGlobalStateManager.hpp"
 
 #include "cef-headers.hpp"
-#include <include/cef_parser.h>		// CefParseJSON, CefWriteJSON
+#include <include/cef_parser.h> // CefParseJSON, CefWriteJSON
 
 #include <QUuid>
 #include <QMainWindow>
 #include <QSpacerItem>
 
-#include <algorithm>    // std::sort
+#include <algorithm> // std::sort
 #include <functional>
 #include <regex>
 
@@ -18,8 +18,7 @@
 
 static const bool ENABLE_CUSTOM_DOCK_WIDGET_TITLE_BAR = true;
 
-class LocalTitleWidget : public QWidget
-{
+class LocalTitleWidget : public QWidget {
 private:
 	void updateStyleSheet()
 	{
@@ -35,15 +34,14 @@ private:
 	}
 
 public:
-	LocalTitleWidget(QWidget* parent) : QWidget(parent)
+	LocalTitleWidget(QWidget *parent) : QWidget(parent)
 	{
 		updateStyleSheet();
 	}
 
-	virtual void changeEvent(QEvent* event) override
+	virtual void changeEvent(QEvent *event) override
 	{
-		if (event->type() == QEvent::StyleChange)
-		{
+		if (event->type() == QEvent::StyleChange) {
 			// Style has been changed.
 			updateStyleSheet();
 		}
@@ -71,7 +69,7 @@ public:
 
 	int titleHeight() const
 	{
-		QDockWidget *q = qobject_cast<QDockWidget*>(parentWidget());
+		QDockWidget *q = qobject_cast<QDockWidget *>(parentWidget());
 
 		QSize items(0, 0);
 		for (int i = 0; i < layout()->count(); ++i) {
@@ -79,33 +77,34 @@ public:
 
 			if (i == 0) {
 				items = curr;
-			}
-			else {
-				items = QSize(qMax(curr.width(), items.width()), qMax(curr.height(), items.height()));
+			} else {
+				items = QSize(qMax(curr.width(), items.width()),
+					      qMax(curr.height(),
+						   items.height()));
 			}
 		}
 
 		int buttonHeight = qMax(
 			items.height(),
 			style()->pixelMetric(QStyle::PM_SmallIconSize, 0, q) +
-			q->style()->pixelMetric(QStyle::PM_DockWidgetTitleBarButtonMargin, 0, q)
-		);
-
+				q->style()->pixelMetric(
+					QStyle::PM_DockWidgetTitleBarButtonMargin,
+					0, q));
 
 		QFontMetrics titleFontMetrics = q->fontMetrics();
 		int mw =
-			q->style()->pixelMetric(QStyle::PM_DockWidgetTitleMargin, 0, q) * 2 +
+			q->style()->pixelMetric(
+				QStyle::PM_DockWidgetTitleMargin, 0, q) *
+				2 +
 			//q->style()->pixelMetric(QStyle::PM_DockWidgetTitleBarButtonMargin, 0, q) +
-			q->style()->pixelMetric(QStyle::PM_DockWidgetFrameWidth, 0, q) +
+			q->style()->pixelMetric(QStyle::PM_DockWidgetFrameWidth,
+						0, q) +
 			0;
 
 		return qMax(buttonHeight, titleFontMetrics.height() + mw);
 	}
 
-	virtual QSize minimumSizeHint() const override
-	{
-		return sizeHint();
-	}
+	virtual QSize minimumSizeHint() const override { return sizeHint(); }
 
 	virtual QSize sizeHint() const override
 	{
@@ -126,8 +125,7 @@ public:
 	}
 };
 
-class LocalTitleLabel : public QLabel
-{
+class LocalTitleLabel : public QLabel {
 private:
 	void updateStyleSheet()
 	{
@@ -143,16 +141,13 @@ private:
 	}
 
 public:
-	LocalTitleLabel(QString label) :
-		QLabel(label)
-	{
-	}
+	LocalTitleLabel(QString label) : QLabel(label) {}
 
 protected:
-	virtual void changeEvent(QEvent* event) override
+	virtual void changeEvent(QEvent *event) override
 	{
-		if (event->type() == QEvent::StyleChange || event->type() == QEvent::ScreenChangeInternal)
-		{
+		if (event->type() == QEvent::StyleChange ||
+		    event->type() == QEvent::ScreenChangeInternal) {
 			// Style has been changed.
 			updateStyleSheet();
 		}
@@ -163,8 +158,7 @@ protected:
 	}
 };
 
-class LocalToolButton : public QToolButton
-{
+class LocalToolButton : public QToolButton {
 private:
 	mutable int m_iconSize = -1;
 
@@ -177,10 +171,10 @@ public:
 		//updateStyleSheet(true);
 	}
 
-	virtual void changeEvent(QEvent* event) override
+	virtual void changeEvent(QEvent *event) override
 	{
-		if (event->type() == QEvent::StyleChange || event->type() == QEvent::ScreenChangeInternal)
-		{
+		if (event->type() == QEvent::StyleChange ||
+		    event->type() == QEvent::ScreenChangeInternal) {
 			// Style has been changed.
 			//updateStyleSheet();
 		}
@@ -191,21 +185,23 @@ public:
 		QToolButton::changeEvent(event);
 	}
 
-	virtual void paintEvent(QPaintEvent*) override
+	virtual void paintEvent(QPaintEvent *) override
 	{
 		QPainter p(this);
 		QStyleOptionToolButton opt;
 		opt.initFrom(this);
 		opt.state |= QStyle::State_AutoRaise;
-		if (style()->styleHint(QStyle::SH_DockWidget_ButtonsHaveFrame, 0, this))
-		{
-			if (isEnabled() && underMouse() && !isChecked() && !isDown())
+		if (style()->styleHint(QStyle::SH_DockWidget_ButtonsHaveFrame,
+				       0, this)) {
+			if (isEnabled() && underMouse() && !isChecked() &&
+			    !isDown())
 				opt.state |= QStyle::State_Raised;
 			if (isChecked())
 				opt.state |= QStyle::State_On;
 			if (isDown())
 				opt.state |= QStyle::State_Sunken;
-			style()->drawPrimitive(QStyle::PE_PanelButtonTool, &opt, &p, this);
+			style()->drawPrimitive(QStyle::PE_PanelButtonTool, &opt,
+					       &p, this);
 		}
 
 		opt.icon = icon();
@@ -214,13 +210,14 @@ public:
 		opt.features = QStyleOptionToolButton::None;
 		opt.arrowType = Qt::NoArrow;
 		opt.iconSize = dockButtonIconSize(&opt);
-		style()->drawComplexControl(QStyle::CC_ToolButton, &opt, &p, this);
+		style()->drawComplexControl(QStyle::CC_ToolButton, &opt, &p,
+					    this);
 	}
 
 	static inline bool isWindowsStyle(const QStyle *style)
 	{
 		// Note: QStyleSheetStyle inherits QWindowsStyle
-		const QStyle *effectiveStyle = style;	
+		const QStyle *effectiveStyle = style;
 
 		//if (style->inherits("QStyleSheetStyle"))
 		//	effectiveStyle = static_cast<const QStyleSheetStyle *>(style)->baseStyle();
@@ -228,17 +225,19 @@ public:
 		return effectiveStyle->inherits("QWindowsStyle");
 	}
 
-	QSize dockButtonIconSize(QStyleOption* styleOption) const
+	QSize dockButtonIconSize(QStyleOption *styleOption) const
 	{
 		if (m_iconSize < 0) {
-			m_iconSize = style()->pixelMetric(QStyle::PM_SmallIconSize, styleOption, this);
+			m_iconSize = style()->pixelMetric(
+				QStyle::PM_SmallIconSize, styleOption, this);
 
 			// Dock Widget title buttons on Windows where historically limited to size 10
 			// (from small icon size 16) since only a 10x10 XPM was provided.
 			// Adding larger pixmaps to the icons thus caused the icons to grow; limit
 			// this to qpiScaled(10) here.
 			if (isWindowsStyle(style())) {
-				m_iconSize = qMin((10 * logicalDpiX()) / 96, m_iconSize);
+				m_iconSize = qMin((10 * logicalDpiX()) / 96,
+						  m_iconSize);
 			}
 		}
 
@@ -248,9 +247,13 @@ public:
 	virtual QSize sizeHint() const override
 	{
 		ensurePolished();
-		int size = 2 * style()->pixelMetric(QStyle::PM_DockWidgetTitleBarButtonMargin, 0, this);
+		int size =
+			2 * style()->pixelMetric(
+				    QStyle::PM_DockWidgetTitleBarButtonMargin,
+				    0, this);
 		if (!icon().isNull()) {
-			const QSize sz = icon().actualSize(dockButtonIconSize(nullptr));
+			const QSize sz =
+				icon().actualSize(dockButtonIconSize(nullptr));
 			size += qMax(sz.width(), sz.height());
 		}
 		return QSize(size, size);
@@ -258,31 +261,29 @@ public:
 
 	virtual void enterEvent(QEvent *event) override
 	{
-		if (isEnabled()) update();
+		if (isEnabled())
+			update();
 		QAbstractButton::enterEvent(event);
 	}
 
 	virtual void leaveEvent(QEvent *event) override
 	{
-		if (isEnabled()) update();
+		if (isEnabled())
+			update();
 		QAbstractButton::leaveEvent(event);
 	}
-
 };
 
-StreamElementsBrowserWidgetManager::StreamElementsBrowserWidgetManager(QMainWindow* parent) :
-	StreamElementsWidgetManager(parent),
-	m_notificationBarToolBar(nullptr)
+StreamElementsBrowserWidgetManager::StreamElementsBrowserWidgetManager(
+	QMainWindow *parent)
+	: StreamElementsWidgetManager(parent), m_notificationBarToolBar(nullptr)
 {
 }
 
-StreamElementsBrowserWidgetManager::~StreamElementsBrowserWidgetManager()
-{
-}
+StreamElementsBrowserWidgetManager::~StreamElementsBrowserWidgetManager() {}
 
 void StreamElementsBrowserWidgetManager::PushCentralBrowserWidget(
-	const char* const url,
-	const char* const executeJavaScriptCodeOnLoad)
+	const char *const url, const char *const executeJavaScriptCodeOnLoad)
 {
 	if (!url) {
 		return;
@@ -292,7 +293,8 @@ void StreamElementsBrowserWidgetManager::PushCentralBrowserWidget(
 
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-	StreamElementsBrowserWidget* widget = new StreamElementsBrowserWidget(nullptr, url, executeJavaScriptCodeOnLoad, "center", "");
+	StreamElementsBrowserWidget *widget = new StreamElementsBrowserWidget(
+		nullptr, url, executeJavaScriptCodeOnLoad, "center", "");
 
 	PushCentralWidget(widget);
 }
@@ -304,7 +306,8 @@ bool StreamElementsBrowserWidgetManager::DestroyCurrentCentralBrowserWidget()
 	return DestroyCurrentCentralWidget();
 }
 
-std::string StreamElementsBrowserWidgetManager::AddDockBrowserWidget(CefRefPtr<CefValue> input, std::string requestId)
+std::string StreamElementsBrowserWidgetManager::AddDockBrowserWidget(
+	CefRefPtr<CefValue> input, std::string requestId)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
@@ -325,13 +328,15 @@ std::string StreamElementsBrowserWidgetManager::AddDockBrowserWidget(CefRefPtr<C
 	}
 
 	if (widgetDictionary.get()) {
-		if (widgetDictionary->HasKey("title") && widgetDictionary->HasKey("url")) {
+		if (widgetDictionary->HasKey("title") &&
+		    widgetDictionary->HasKey("url")) {
 			std::string title;
 			std::string url;
 			std::string dockingAreaString = "floating";
 			std::string executeJavaScriptOnLoad;
 			bool visible = true;
-			QSizePolicy sizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+			QSizePolicy sizePolicy(QSizePolicy::Preferred,
+					       QSizePolicy::Preferred);
 			int requestWidth = 100;
 			int requestHeight = 100;
 			int minWidth = 0;
@@ -345,11 +350,15 @@ std::string StreamElementsBrowserWidgetManager::AddDockBrowserWidget(CefRefPtr<C
 			url = widgetDictionary->GetString("url");
 
 			if (widgetDictionary->HasKey("dockingArea")) {
-				dockingAreaString = widgetDictionary->GetString("dockingArea");
+				dockingAreaString = widgetDictionary->GetString(
+					"dockingArea");
 			}
 
-			if (widgetDictionary->HasKey("executeJavaScriptOnLoad")) {
-				executeJavaScriptOnLoad = widgetDictionary->GetString("executeJavaScriptOnLoad");
+			if (widgetDictionary->HasKey(
+				    "executeJavaScriptOnLoad")) {
+				executeJavaScriptOnLoad =
+					widgetDictionary->GetString(
+						"executeJavaScriptOnLoad");
 			}
 
 			if (widgetDictionary->HasKey("visible")) {
@@ -360,24 +369,25 @@ std::string StreamElementsBrowserWidgetManager::AddDockBrowserWidget(CefRefPtr<C
 
 			if (dockingAreaString == "left") {
 				dockingArea = Qt::LeftDockWidgetArea;
-				sizePolicy.setVerticalPolicy(QSizePolicy::Expanding);
-			}
-			else if (dockingAreaString == "right") {
+				sizePolicy.setVerticalPolicy(
+					QSizePolicy::Expanding);
+			} else if (dockingAreaString == "right") {
 				dockingArea = Qt::RightDockWidgetArea;
-				sizePolicy.setVerticalPolicy(QSizePolicy::Expanding);
-			}
-			else if (dockingAreaString == "top") {
+				sizePolicy.setVerticalPolicy(
+					QSizePolicy::Expanding);
+			} else if (dockingAreaString == "top") {
 				dockingArea = Qt::TopDockWidgetArea;
-				sizePolicy.setHorizontalPolicy(QSizePolicy::Expanding);
-			}
-			else if (dockingAreaString == "bottom") {
+				sizePolicy.setHorizontalPolicy(
+					QSizePolicy::Expanding);
+			} else if (dockingAreaString == "bottom") {
 				dockingArea = Qt::BottomDockWidgetArea;
-				sizePolicy.setHorizontalPolicy(QSizePolicy::Expanding);
-			}
-			else
-			{
-				sizePolicy.setHorizontalPolicy(QSizePolicy::Expanding);
-				sizePolicy.setVerticalPolicy(QSizePolicy::Expanding);
+				sizePolicy.setHorizontalPolicy(
+					QSizePolicy::Expanding);
+			} else {
+				sizePolicy.setHorizontalPolicy(
+					QSizePolicy::Expanding);
+				sizePolicy.setVerticalPolicy(
+					QSizePolicy::Expanding);
 			}
 
 			if (widgetDictionary->HasKey("minWidth")) {
@@ -385,15 +395,18 @@ std::string StreamElementsBrowserWidgetManager::AddDockBrowserWidget(CefRefPtr<C
 			}
 
 			if (widgetDictionary->HasKey("width")) {
-				requestWidth = widgetDictionary->GetInt("width");
+				requestWidth =
+					widgetDictionary->GetInt("width");
 			}
 
 			if (widgetDictionary->HasKey("minHeight")) {
-				minHeight = widgetDictionary->GetInt("minHeight");
+				minHeight =
+					widgetDictionary->GetInt("minHeight");
 			}
 
 			if (widgetDictionary->HasKey("height")) {
-				requestHeight = widgetDictionary->GetInt("height");
+				requestHeight =
+					widgetDictionary->GetInt("height");
 			}
 
 			if (widgetDictionary->HasKey("left")) {
@@ -405,12 +418,10 @@ std::string StreamElementsBrowserWidgetManager::AddDockBrowserWidget(CefRefPtr<C
 			}
 
 			if (AddDockBrowserWidget(
-				id.c_str(),
-				title.c_str(),
-				url.c_str(),
-				executeJavaScriptOnLoad.c_str(),
-				dockingArea)) {
-				QDockWidget* widget = GetDockWidget(id.c_str());
+				    id.c_str(), title.c_str(), url.c_str(),
+				    executeJavaScriptOnLoad.c_str(),
+				    dockingArea)) {
+				QDockWidget *widget = GetDockWidget(id.c_str());
 
 				widget->setVisible(!visible);
 				QApplication::sendPostedEvents();
@@ -421,12 +432,14 @@ std::string StreamElementsBrowserWidgetManager::AddDockBrowserWidget(CefRefPtr<C
 				widget->widget()->setSizePolicy(sizePolicy);
 
 				//widget->setMinimumSize(requestWidth, requestHeight);
-				widget->widget()->setMinimumSize(requestWidth, requestHeight);
+				widget->widget()->setMinimumSize(requestWidth,
+								 requestHeight);
 
 				QApplication::sendPostedEvents();
 
 				//widget->setMinimumSize(minWidth, minHeight);
-				widget->widget()->setMinimumSize(minWidth, minHeight);
+				widget->widget()->setMinimumSize(minWidth,
+								 minHeight);
 
 				if (left >= 0 || top >= 0) {
 					widget->move(left, top);
@@ -443,19 +456,16 @@ std::string StreamElementsBrowserWidgetManager::AddDockBrowserWidget(CefRefPtr<C
 }
 
 bool StreamElementsBrowserWidgetManager::AddDockBrowserWidget(
-	const char* const id,
-	const char* const title,
-	const char* const url,
-	const char* const executeJavaScriptCodeOnLoad,
-	const Qt::DockWidgetArea area,
-	const Qt::DockWidgetAreas allowedAreas,
+	const char *const id, const char *const title, const char *const url,
+	const char *const executeJavaScriptCodeOnLoad,
+	const Qt::DockWidgetArea area, const Qt::DockWidgetAreas allowedAreas,
 	const QDockWidget::DockWidgetFeatures features)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
 	const bool enableBackForwardNavigation = false;
 
-	QMainWindow* main = new QMainWindow(nullptr);
+	QMainWindow *main = new QMainWindow(nullptr);
 
 	//QAction* floatAction = new QAction("🗗");
 	//QAction* closeAction = new QAction("×");
@@ -463,12 +473,19 @@ bool StreamElementsBrowserWidgetManager::AddDockBrowserWidget(
 	//QAction* forwardAction = new QAction("❯");
 	//QAction* reloadAction = new QAction("☀");
 
-	QAction* backAction = new QAction(qApp->style()->standardIcon(QStyle::SP_ArrowLeft), "");
-	QAction* forwardAction = new QAction(qApp->style()->standardIcon(QStyle::SP_ArrowRight), "");
+	QAction *backAction = new QAction(
+		qApp->style()->standardIcon(QStyle::SP_ArrowLeft), "");
+	QAction *forwardAction = new QAction(
+		qApp->style()->standardIcon(QStyle::SP_ArrowRight), "");
 	//QAction* reloadAction = new QAction(qApp->style()->standardIcon(QStyle::SP_BrowserReload), "");
-	QAction* reloadAction = new QAction(QIcon(QPixmap(":/images/toolbar/reload.png")), "");
-	QAction* floatAction = new QAction(qApp->style()->standardIcon(QStyle::SP_TitleBarNormalButton), "");
-	QAction* closeAction = new QAction(qApp->style()->standardIcon(QStyle::SP_TitleBarCloseButton), "");	
+	QAction *reloadAction =
+		new QAction(QIcon(QPixmap(":/images/toolbar/reload.png")), "");
+	QAction *floatAction = new QAction(
+		qApp->style()->standardIcon(QStyle::SP_TitleBarNormalButton),
+		"");
+	QAction *closeAction = new QAction(
+		qApp->style()->standardIcon(QStyle::SP_TitleBarCloseButton),
+		"");
 
 	QFont font;
 	font.setStyleStrategy(QFont::PreferAntialias);
@@ -482,47 +499,37 @@ bool StreamElementsBrowserWidgetManager::AddDockBrowserWidget(
 	backAction->setEnabled(false);
 	forwardAction->setEnabled(false);
 
-	StreamElementsBrowserWidget* widget = new StreamElementsBrowserWidget(
-		nullptr, url, executeJavaScriptCodeOnLoad, DockWidgetAreaToString(area).c_str(), id);
+	StreamElementsBrowserWidget *widget = new StreamElementsBrowserWidget(
+		nullptr, url, executeJavaScriptCodeOnLoad,
+		DockWidgetAreaToString(area).c_str(), id);
 
-	widget->connect(
-		widget,
-		&StreamElementsBrowserWidget::browserStateChanged,
-		[this, widget, backAction, forwardAction]() {
-		backAction->setEnabled(widget->BrowserHistoryCanGoBack());
-		forwardAction->setEnabled(widget->BrowserHistoryCanGoForward());
-	});
+	widget->connect(widget,
+			&StreamElementsBrowserWidget::browserStateChanged,
+			[this, widget, backAction, forwardAction]() {
+				backAction->setEnabled(
+					widget->BrowserHistoryCanGoBack());
+				forwardAction->setEnabled(
+					widget->BrowserHistoryCanGoForward());
+			});
 
 	main->setCentralWidget(widget);
 
-	reloadAction->connect(
-		reloadAction,
-		&QAction::triggered,
-		[widget] {
-		widget->BrowserReload(true);
-	});
+	reloadAction->connect(reloadAction, &QAction::triggered,
+			      [widget] { widget->BrowserReload(true); });
 
-	backAction->connect(
-		backAction,
-		&QAction::triggered,
-		[widget] {
-		widget->BrowserHistoryGoBack();
-	});
+	backAction->connect(backAction, &QAction::triggered,
+			    [widget] { widget->BrowserHistoryGoBack(); });
 
-	forwardAction->connect(
-		backAction,
-		&QAction::triggered,
-		[widget] {
-		widget->BrowserHistoryGoForward();
-	});
+	forwardAction->connect(backAction, &QAction::triggered,
+			       [widget] { widget->BrowserHistoryGoForward(); });
 
 	if (AddDockWidget(id, title, main, area, allowedAreas, features)) {
 		m_browserWidgets[id] = widget;
 
-		QDockWidget* dock = GetDockWidget(id);
+		QDockWidget *dock = GetDockWidget(id);
 
 		if (ENABLE_CUSTOM_DOCK_WIDGET_TITLE_BAR) {
-			QWidget* titleWidget = new LocalTitleWidget(dock);
+			QWidget *titleWidget = new LocalTitleWidget(dock);
 
 			titleWidget->setLayout(new QHBoxLayout());
 			titleWidget->layout()->setMargin(2);
@@ -532,7 +539,8 @@ bool StreamElementsBrowserWidgetManager::AddDockBrowserWidget(
 			//QString buttonStyle = "QToolButton { border: none; padding: 4px; font-weight: bold; } QToolButton:!hover { background-color: transparent; }";
 			//QString labelStyle = "QLabel { background-color: transparent; padding: 2px; }";
 
-			auto createButton = [&](QAction* action, const char* toolTipText) {
+			auto createButton = [&](QAction *action,
+						const char *toolTipText) {
 				auto result = new LocalToolButton();
 
 				result->setDefaultAction(action);
@@ -543,27 +551,42 @@ bool StreamElementsBrowserWidgetManager::AddDockBrowserWidget(
 				return result;
 			};
 
-			auto backButton = createButton(backAction, obs_module_text("StreamElements.Action.BrowserBack.Tooltip"));
-			auto forwardButton = createButton(forwardAction, obs_module_text("StreamElements.Action.BrowserForward.Tooltip"));
-			auto reloadButton = createButton(reloadAction, obs_module_text("StreamElements.Action.BrowserReload.Tooltip"));
-			auto floatButton = createButton(floatAction, obs_module_text("StreamElements.Action.DockToggleFloat.Tooltip"));
-			auto closeButton = createButton(closeAction, obs_module_text("StreamElements.Action.DockHide.Tooltip"));
+			auto backButton = createButton(
+				backAction,
+				obs_module_text(
+					"StreamElements.Action.BrowserBack.Tooltip"));
+			auto forwardButton = createButton(
+				forwardAction,
+				obs_module_text(
+					"StreamElements.Action.BrowserForward.Tooltip"));
+			auto reloadButton = createButton(
+				reloadAction,
+				obs_module_text(
+					"StreamElements.Action.BrowserReload.Tooltip"));
+			auto floatButton = createButton(
+				floatAction,
+				obs_module_text(
+					"StreamElements.Action.DockToggleFloat.Tooltip"));
+			auto closeButton = createButton(
+				closeAction,
+				obs_module_text(
+					"StreamElements.Action.DockHide.Tooltip"));
 
 			floatAction->connect(
-				floatAction,
-				&QAction::triggered,
-				[dock] {
-				dock->setFloating(!dock->isFloating());
-			});
+				floatAction, &QAction::triggered, [dock] {
+					dock->setFloating(!dock->isFloating());
+				});
 
-			closeAction->connect(
-				closeAction,
-				&QAction::triggered,
-				[dock] {
+			closeAction->connect(closeAction, &QAction::triggered, [dock] {
 				dock->setVisible(false);
 
-				StreamElementsGlobalStateManager::GetInstance()->
-					GetAnalyticsEventsManager()->trackDockWidgetEvent(dock, "Hide", json11::Json::object{ { "actionSource", "Docking widget title bar" } });
+				StreamElementsGlobalStateManager::GetInstance()
+					->GetAnalyticsEventsManager()
+					->trackDockWidgetEvent(
+						dock, "Hide",
+						json11::Json::object{
+							{"actionSource",
+							 "Docking widget title bar"}});
 			});
 
 			auto windowTitle = new LocalTitleLabel(title);
@@ -582,35 +605,27 @@ bool StreamElementsBrowserWidgetManager::AddDockBrowserWidget(
 			titleWidget->layout()->addWidget(closeButton);
 
 			backButton->connect(
-				backButton,
-				&QToolButton::click,
-				[this, widget]
-			{
-				widget->BrowserHistoryGoBack();
-			});
+				backButton, &QToolButton::click,
+				[this, widget] {
+					widget->BrowserHistoryGoBack();
+				});
 
 			forwardButton->connect(
-				forwardButton,
-				&QToolButton::click,
-				[this, widget]
-			{
-				widget->BrowserHistoryGoForward();
-			});
+				forwardButton, &QToolButton::click,
+				[this, widget] {
+					widget->BrowserHistoryGoForward();
+				});
 
-			reloadButton->connect(
-				reloadButton,
-				&QToolButton::click,
-				[this, widget]
-			{
-				widget->BrowserReload(true);
-			});
+			reloadButton->connect(reloadButton, &QToolButton::click,
+					      [this, widget] {
+						      widget->BrowserReload(
+							      true);
+					      });
 
-			dock->connect(
-				dock,
-				&QDockWidget::windowTitleChanged,
-				[windowTitle](const QString value) {
-				windowTitle->setText(value);
-			});
+			dock->connect(dock, &QDockWidget::windowTitleChanged,
+				      [windowTitle](const QString value) {
+					      windowTitle->setText(value);
+				      });
 		}
 
 		return true;
@@ -619,25 +634,43 @@ bool StreamElementsBrowserWidgetManager::AddDockBrowserWidget(
 	}
 }
 
-bool StreamElementsBrowserWidgetManager::ToggleWidgetFloatingStateById(const char* const id)
+bool StreamElementsBrowserWidgetManager::ToggleWidgetFloatingStateById(
+	const char *const id)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
 	return StreamElementsWidgetManager::ToggleWidgetFloatingStateById(id);
 }
 
-bool StreamElementsBrowserWidgetManager::SetWidgetDimensionsById(const char* const id, const int width, const int height)
+bool StreamElementsBrowserWidgetManager::SetWidgetDimensionsById(
+	const char *const id, const int width, const int height)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-	return StreamElementsWidgetManager::SetWidgetDimensionsById(id, width, height);
+	return StreamElementsWidgetManager::SetWidgetDimensionsById(id, width,
+								    height);
 }
 
-bool StreamElementsBrowserWidgetManager::SetWidgetPositionById(const char* const id, const int left, const int top)
+bool StreamElementsBrowserWidgetManager::SetWidgetPositionById(
+	const char *const id, const int left, const int top)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-	return StreamElementsWidgetManager::SetWidgetPositionById(id, left, top);
+	return StreamElementsWidgetManager::SetWidgetPositionById(id, left,
+								  top);
+}
+
+bool StreamElementsBrowserWidgetManager::SetWidgetUrlById(const char *const id,
+							  const char *const url)
+{
+	std::lock_guard<std::recursive_mutex> guard(m_mutex);
+
+	if (!m_browserWidgets.count(id))
+		return false;
+
+	m_browserWidgets[id]->BrowserLoadInitialPage(url);
+
+	return true;
 }
 
 void StreamElementsBrowserWidgetManager::RemoveAllDockWidgets()
@@ -649,7 +682,7 @@ void StreamElementsBrowserWidgetManager::RemoveAllDockWidgets()
 	}
 }
 
-bool StreamElementsBrowserWidgetManager::RemoveDockWidget(const char* const id)
+bool StreamElementsBrowserWidgetManager::RemoveDockWidget(const char *const id)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
@@ -664,40 +697,48 @@ bool StreamElementsBrowserWidgetManager::RemoveDockWidget(const char* const id)
 	return false;
 }
 
-void StreamElementsBrowserWidgetManager::GetDockBrowserWidgetIdentifiers(std::vector<std::string>& result)
+void StreamElementsBrowserWidgetManager::GetDockBrowserWidgetIdentifiers(
+	std::vector<std::string> &result)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
 	return GetDockWidgetIdentifiers(result);
 }
 
-StreamElementsBrowserWidgetManager::DockBrowserWidgetInfo* StreamElementsBrowserWidgetManager::GetDockBrowserWidgetInfo(const char* const id)
+StreamElementsBrowserWidgetManager::DockBrowserWidgetInfo *
+StreamElementsBrowserWidgetManager::GetDockBrowserWidgetInfo(
+	const char *const id)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-	StreamElementsBrowserWidgetManager::DockWidgetInfo* baseInfo = GetDockWidgetInfo(id);
+	StreamElementsBrowserWidgetManager::DockWidgetInfo *baseInfo =
+		GetDockWidgetInfo(id);
 
 	if (!baseInfo) {
 		return nullptr;
 	}
 
-	StreamElementsBrowserWidgetManager::DockBrowserWidgetInfo* result =
-		new StreamElementsBrowserWidgetManager::DockBrowserWidgetInfo(*baseInfo);
+	StreamElementsBrowserWidgetManager::DockBrowserWidgetInfo *result =
+		new StreamElementsBrowserWidgetManager::DockBrowserWidgetInfo(
+			*baseInfo);
 
 	delete baseInfo;
 
 	result->m_url = m_browserWidgets[id]->GetStartUrl();
 
-	result->m_executeJavaScriptOnLoad = m_browserWidgets[id]->GetExecuteJavaScriptCodeOnLoad();
+	result->m_executeJavaScriptOnLoad =
+		m_browserWidgets[id]->GetExecuteJavaScriptCodeOnLoad();
 
 	return result;
 }
 
-void StreamElementsBrowserWidgetManager::SerializeDockingWidgets(CefRefPtr<CefValue>& output)
+void StreamElementsBrowserWidgetManager::SerializeDockingWidgets(
+	CefRefPtr<CefValue> &output)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-	CefRefPtr<CefDictionaryValue> rootDictionary = CefDictionaryValue::Create();
+	CefRefPtr<CefDictionaryValue> rootDictionary =
+		CefDictionaryValue::Create();
 	output->SetDictionary(rootDictionary);
 
 	std::vector<std::string> widgetIdentifiers;
@@ -706,21 +747,25 @@ void StreamElementsBrowserWidgetManager::SerializeDockingWidgets(CefRefPtr<CefVa
 
 	for (auto id : widgetIdentifiers) {
 		CefRefPtr<CefValue> widgetValue = CefValue::Create();
-		CefRefPtr<CefDictionaryValue> widgetDictionary = CefDictionaryValue::Create();
+		CefRefPtr<CefDictionaryValue> widgetDictionary =
+			CefDictionaryValue::Create();
 		widgetValue->SetDictionary(widgetDictionary);
 
-		StreamElementsBrowserWidgetManager::DockBrowserWidgetInfo* info =
+		StreamElementsBrowserWidgetManager::DockBrowserWidgetInfo *info =
 			GetDockBrowserWidgetInfo(id.c_str());
 
 		if (info) {
 			widgetDictionary->SetString("id", id);
 			widgetDictionary->SetString("url", info->m_url);
-			widgetDictionary->SetString("dockingArea", info->m_dockingArea);
+			widgetDictionary->SetString("dockingArea",
+						    info->m_dockingArea);
 			widgetDictionary->SetString("title", info->m_title);
-			widgetDictionary->SetString("executeJavaScriptOnLoad", info->m_executeJavaScriptOnLoad);
+			widgetDictionary->SetString(
+				"executeJavaScriptOnLoad",
+				info->m_executeJavaScriptOnLoad);
 			widgetDictionary->SetBool("visible", info->m_visible);
 
-			QDockWidget* widget = GetDockWidget(id.c_str());
+			QDockWidget *widget = GetDockWidget(id.c_str());
 
 			QSize minSize = widget->widget()->minimumSize();
 			QSize size = widget->size();
@@ -739,7 +784,8 @@ void StreamElementsBrowserWidgetManager::SerializeDockingWidgets(CefRefPtr<CefVa
 	}
 }
 
-void StreamElementsBrowserWidgetManager::DeserializeDockingWidgets(CefRefPtr<CefValue>& input)
+void StreamElementsBrowserWidgetManager::DeserializeDockingWidgets(
+	CefRefPtr<CefValue> &input)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
@@ -747,8 +793,7 @@ void StreamElementsBrowserWidgetManager::DeserializeDockingWidgets(CefRefPtr<Cef
 		return;
 	}
 
-	CefRefPtr<CefDictionaryValue> rootDictionary =
-		input->GetDictionary();
+	CefRefPtr<CefDictionaryValue> rootDictionary = input->GetDictionary();
 
 	CefDictionaryValue::KeyList rootDictionaryKeys;
 
@@ -772,19 +817,26 @@ void StreamElementsBrowserWidgetManager::DeserializeDockingWidgets(CefRefPtr<Cef
 		CefRefPtr<CefValue> widgetValue = rootDictionary->GetValue(id);
 
 		if (widgetValue->GetDictionary()->HasKey("dockingArea")) {
-			std::string area = widgetValue->GetDictionary()->GetString("dockingArea").ToString();
+			std::string area = widgetValue->GetDictionary()
+						   ->GetString("dockingArea")
+						   .ToString();
 
 			int start = -1;
 			int secondary = -1;
 
-			if (widgetValue->GetDictionary()->HasKey("left") && widgetValue->GetDictionary()->HasKey("top")) {
+			if (widgetValue->GetDictionary()->HasKey("left") &&
+			    widgetValue->GetDictionary()->HasKey("top")) {
 				if ((area == "left" || area == "right")) {
-					start = widgetValue->GetDictionary()->GetInt("top");
-					secondary = widgetValue->GetDictionary()->GetInt("left");
-				}
-				else if ((area == "top" || area == "bottom")) {
-					start = widgetValue->GetDictionary()->GetInt("left");
-					secondary = widgetValue->GetDictionary()->GetInt("top");
+					start = widgetValue->GetDictionary()
+							->GetInt("top");
+					secondary = widgetValue->GetDictionary()
+							    ->GetInt("left");
+				} else if ((area == "top" ||
+					    area == "bottom")) {
+					start = widgetValue->GetDictionary()
+							->GetInt("left");
+					secondary = widgetValue->GetDictionary()
+							    ->GetInt("top");
 				}
 			}
 
@@ -795,28 +847,35 @@ void StreamElementsBrowserWidgetManager::DeserializeDockingWidgets(CefRefPtr<Cef
 
 	// 2. For each area
 	//
-	for (docks_map_t::iterator areaPair = docksMap.begin(); areaPair != docksMap.end(); ++areaPair) {
+	for (docks_map_t::iterator areaPair = docksMap.begin();
+	     areaPair != docksMap.end(); ++areaPair) {
 		std::string area = areaPair->first;
 
-		for (start_to_ids_map_t::iterator startPair = areaPair->second.begin(); startPair != areaPair->second.end(); ++startPair) {
+		for (start_to_ids_map_t::iterator startPair =
+			     areaPair->second.begin();
+		     startPair != areaPair->second.end(); ++startPair) {
 			//int start = startPair->first;
 			id_arr_t dockIds = startPair->second;
 
 			// 3. Sort dock IDs by secondary start coord
-			std::sort(dockIds.begin(), dockIds.end(), [&](std::string i, std::string j) -> bool {
-				return secondaryStartMap[i] < secondaryStartMap[j];
-			});
+			std::sort(dockIds.begin(), dockIds.end(),
+				  [&](std::string i, std::string j) -> bool {
+					  return secondaryStartMap[i] <
+						 secondaryStartMap[j];
+				  });
 
 			std::map<std::string, QSize> idToMinSizeMap;
 
 			// 4. For each dock Id
 			//
 			for (int i = 0; i < dockIds.size(); ++i) {
-				CefRefPtr<CefValue> widgetValue = rootDictionary->GetValue(dockIds[i]);
+				CefRefPtr<CefValue> widgetValue =
+					rootDictionary->GetValue(dockIds[i]);
 
 				// 5. Create docking widget
 				//
-				dockIds[i] = AddDockBrowserWidget(widgetValue, dockIds[i]);
+				dockIds[i] = AddDockBrowserWidget(widgetValue,
+								  dockIds[i]);
 
 				/*
 				QDockWidget* prev = i > 0 ? GetDockWidget(dockIds[i - 1].c_str()) : nullptr;
@@ -844,20 +903,19 @@ void StreamElementsBrowserWidgetManager::DeserializeDockingWidgets(CefRefPtr<Cef
 				*/
 			}
 		}
-
 	}
 }
 
 void StreamElementsBrowserWidgetManager::ShowNotificationBar(
-	const char* const url,
-	const int height,
-	const char* const executeJavaScriptCodeOnLoad)
+	const char *const url, const int height,
+	const char *const executeJavaScriptCodeOnLoad)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
 	HideNotificationBar();
 
-	m_notificationBarBrowserWidget = new StreamElementsBrowserWidget(nullptr, url, executeJavaScriptCodeOnLoad, "notification", "");
+	m_notificationBarBrowserWidget = new StreamElementsBrowserWidget(
+		nullptr, url, executeJavaScriptCodeOnLoad, "notification", "");
 
 	const Qt::ToolBarArea NOTIFICATION_BAR_AREA = Qt::TopToolBarArea;
 
@@ -870,7 +928,8 @@ void StreamElementsBrowserWidgetManager::ShowNotificationBar(
 	m_notificationBarToolBar->setMaximumHeight(height);
 	m_notificationBarToolBar->setLayout(new QVBoxLayout());
 	m_notificationBarToolBar->addWidget(m_notificationBarBrowserWidget);
-	mainWindow()->addToolBar(NOTIFICATION_BAR_AREA, m_notificationBarToolBar);
+	mainWindow()->addToolBar(NOTIFICATION_BAR_AREA,
+				 m_notificationBarToolBar);
 }
 
 void StreamElementsBrowserWidgetManager::HideNotificationBar()
@@ -898,29 +957,37 @@ bool StreamElementsBrowserWidgetManager::HasNotificationBar()
 	return !!m_notificationBarToolBar;
 }
 
-void StreamElementsBrowserWidgetManager::SerializeNotificationBar(CefRefPtr<CefValue>& output)
+void StreamElementsBrowserWidgetManager::SerializeNotificationBar(
+	CefRefPtr<CefValue> &output)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
 	if (m_notificationBarToolBar) {
-		CefRefPtr<CefDictionaryValue> rootDictionary = CefDictionaryValue::Create();
+		CefRefPtr<CefDictionaryValue> rootDictionary =
+			CefDictionaryValue::Create();
 		output->SetDictionary(rootDictionary);
 
-		rootDictionary->SetString("url", m_notificationBarBrowserWidget->GetStartUrl());
-		rootDictionary->SetString("executeJavaScriptOnLoad", m_notificationBarBrowserWidget->GetExecuteJavaScriptCodeOnLoad());
-		rootDictionary->SetInt("height", m_notificationBarToolBar->size().height());		
-	}
-	else {
+		rootDictionary->SetString(
+			"url", m_notificationBarBrowserWidget->GetStartUrl());
+		rootDictionary->SetString(
+			"executeJavaScriptOnLoad",
+			m_notificationBarBrowserWidget
+				->GetExecuteJavaScriptCodeOnLoad());
+		rootDictionary->SetInt(
+			"height", m_notificationBarToolBar->size().height());
+	} else {
 		output->SetNull();
 	}
 }
 
-void StreamElementsBrowserWidgetManager::DeserializeNotificationBar(CefRefPtr<CefValue>& input)
+void StreamElementsBrowserWidgetManager::DeserializeNotificationBar(
+	CefRefPtr<CefValue> &input)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
 	if (input->GetType() == VTYPE_DICTIONARY) {
-		CefRefPtr<CefDictionaryValue> rootDictionary = input->GetDictionary();
+		CefRefPtr<CefDictionaryValue> rootDictionary =
+			input->GetDictionary();
 
 		int height = 100;
 		std::string url = "about:blank";
@@ -935,14 +1002,19 @@ void StreamElementsBrowserWidgetManager::DeserializeNotificationBar(CefRefPtr<Ce
 		}
 
 		if (rootDictionary->HasKey("executeJavaScriptOnLoad")) {
-			executeJavaScriptOnLoad = rootDictionary->GetString("executeJavaScriptOnLoad").ToString();
+			executeJavaScriptOnLoad =
+				rootDictionary
+					->GetString("executeJavaScriptOnLoad")
+					.ToString();
 		}
 
-		ShowNotificationBar(url.c_str(), height, executeJavaScriptOnLoad.c_str());
+		ShowNotificationBar(url.c_str(), height,
+				    executeJavaScriptOnLoad.c_str());
 	}
 }
 
-void StreamElementsBrowserWidgetManager::SerializeNotificationBar(std::string& output)
+void StreamElementsBrowserWidgetManager::SerializeNotificationBar(
+	std::string &output)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
@@ -951,19 +1023,19 @@ void StreamElementsBrowserWidgetManager::SerializeNotificationBar(std::string& o
 	SerializeNotificationBar(root);
 
 	// Convert data to JSON
-	CefString jsonString =
-		CefWriteJSON(root, JSON_WRITER_DEFAULT);
+	CefString jsonString = CefWriteJSON(root, JSON_WRITER_DEFAULT);
 
 	output = jsonString.ToString();
 }
 
-void StreamElementsBrowserWidgetManager::DeserializeNotificationBar(std::string& input)
+void StreamElementsBrowserWidgetManager::DeserializeNotificationBar(
+	std::string &input)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
 	// Convert JSON string to CefValue
-	CefRefPtr<CefValue> root =
-		CefParseJSON(CefString(input), JSON_PARSER_ALLOW_TRAILING_COMMAS);
+	CefRefPtr<CefValue> root = CefParseJSON(
+		CefString(input), JSON_PARSER_ALLOW_TRAILING_COMMAS);
 
 	DeserializeNotificationBar(root);
 }

--- a/streamelements/StreamElementsBrowserWidgetManager.hpp
+++ b/streamelements/StreamElementsBrowserWidgetManager.hpp
@@ -66,6 +66,18 @@ public:
 
 	virtual bool SetWidgetDimensionsById(const char* const id, const int width, const int height) override;
 	virtual bool SetWidgetPositionById(const char* const id, const int left, const int top) override;
+	virtual bool SetWidgetUrlById(const char *const id,
+				      const char *const url);
+
+	virtual bool ShowDockWidgetById(const char *const id)
+	{
+		return StreamElementsWidgetManager::ShowWidgetById(id);
+	}
+
+	virtual bool HideDockWidgetById(const char *const id)
+	{
+		return StreamElementsWidgetManager::HideWidgetById(id);
+	}
 
 	virtual bool RemoveDockWidget(const char* const id) override;
 

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -344,6 +344,9 @@ void StreamElementsGlobalStateManager::Initialize(QMainWindow *obs_main_window)
 				new StreamElementsBackupManager();
 			context->self->m_cleanupManager =
 				new StreamElementsCleanupManager();
+			context->self->m_previewManager =
+				new StreamElementsPreviewManager(
+					context->self->mainWindow());
 			context->self->m_windowStateEventFilter =
 				new WindowStateChangeEventFilter(
 					context->self->mainWindow());
@@ -537,6 +540,7 @@ void StreamElementsGlobalStateManager::Shutdown()
 			delete self->m_profilesManager;
 			delete self->m_backupManager;
 			delete self->m_cleanupManager;
+			delete self->m_previewManager;
 			delete self->m_windowStateEventFilter;
 		},
 		this);

--- a/streamelements/StreamElementsGlobalStateManager.hpp
+++ b/streamelements/StreamElementsGlobalStateManager.hpp
@@ -20,6 +20,7 @@
 #include "StreamElementsProfilesManager.hpp"
 #include "StreamElementsBackupManager.hpp"
 #include "StreamElementsCleanupManager.hpp"
+#include "StreamElementsPreviewManager.hpp"
 
 class StreamElementsGlobalStateManager : public StreamElementsObsAppMonitor {
 private:
@@ -140,6 +141,10 @@ public:
 	{
 		return m_cleanupManager;
 	}
+	StreamElementsPreviewManager* GetPreviewManager()
+	{
+		return m_previewManager;
+	}
 	QMainWindow *mainWindow() { return m_mainWindow; }
 
 public:
@@ -161,6 +166,7 @@ private:
 	bool m_persistStateEnabled = false;
 	bool m_initialized = false;
 	QMainWindow *m_mainWindow = nullptr;
+	QWidget *m_nativeCentralWidget = nullptr;
 	StreamElementsBrowserWidgetManager *m_widgetManager = nullptr;
 	StreamElementsObsSceneManager *m_obsSceneManager = nullptr;
 	StreamElementsMenuManager *m_menuManager = nullptr;
@@ -183,6 +189,7 @@ private:
 	StreamElementsProfilesManager *m_profilesManager = nullptr;
 	StreamElementsBackupManager *m_backupManager = nullptr;
 	StreamElementsCleanupManager *m_cleanupManager = nullptr;
+	StreamElementsPreviewManager *m_previewManager = nullptr;
 	WindowStateChangeEventFilter *m_windowStateEventFilter = nullptr;
 
 private:

--- a/streamelements/StreamElementsPreviewManager.cpp
+++ b/streamelements/StreamElementsPreviewManager.cpp
@@ -1,0 +1,86 @@
+#include "StreamElementsPreviewManager.hpp"
+
+#include <obs.h>
+#include <obs-frontend-api.h>
+
+#include <QApplication>
+#include <QEvent>
+
+#include "StreamElementsCefClient.hpp"
+#include "StreamElementsObsAppMonitor.hpp"
+
+static class PreviewMouseEventFilter : public QObject {
+private:
+	QMainWindow *m_mainWindow;
+
+public:
+	PreviewMouseEventFilter(QMainWindow *mainWindow)
+		: m_mainWindow(mainWindow)
+	{
+		QCoreApplication::instance()->installEventFilter(this);
+	}
+
+	virtual ~PreviewMouseEventFilter()
+	{
+		QCoreApplication::instance()->removeEventFilter(this);
+	}
+
+	virtual bool eventFilter(QObject *o, QEvent *e) override
+	{
+		QWidget *centralWidget = m_mainWindow->centralWidget();
+
+		std::string objectName = o->objectName().toStdString();
+
+		switch (e->type()) {
+		case QEvent::MouseButtonDblClick:
+			if (QApplication::keyboardModifiers() ==
+			    Qt::NoModifier) {
+				if (o->objectName() ==
+				    QString("previewWindow")) {
+					StreamElementsCefClient::DispatchJSEvent(
+						"hostVideoPreviewMouseDoubleClicked",
+						"null");
+				} else if (o->objectName() ==
+						   QString("sourcesDockWindow")) {
+					StreamElementsCefClient::DispatchJSEvent(
+						"hostCurrentSceneItemsListMouseDoubleClicked",
+						"null");
+				}
+			}
+			break;
+
+		case QEvent::FocusAboutToChange:
+			if (o->objectName() == "OBSBasicWindow") {
+				StreamElementsCefClient::DispatchJSEvent(
+					"hostBeforeFocusChange", "null");
+			}
+			break;
+		}
+
+		return QObject::eventFilter(o, e);
+	}
+};
+
+StreamElementsPreviewManager::StreamElementsPreviewManager(QMainWindow *parent)
+	: m_parent(parent)
+{
+	m_eventFilter = new PreviewMouseEventFilter(m_parent);
+}
+
+StreamElementsPreviewManager::~StreamElementsPreviewManager()
+{
+	if (m_eventFilter) {
+		delete m_eventFilter;
+
+		m_eventFilter = nullptr;
+	}
+}
+
+void StreamElementsPreviewManager::OnObsExit()
+{
+	if (m_eventFilter) {
+		delete m_eventFilter;
+
+		m_eventFilter = nullptr;
+	}
+}

--- a/streamelements/StreamElementsPreviewManager.hpp
+++ b/streamelements/StreamElementsPreviewManager.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QMainWindow>
+#include <QWidget>
+
+#include "StreamElementsObsAppMonitor.hpp"
+
+class StreamElementsPreviewManager : public StreamElementsObsAppMonitor {
+public:
+	StreamElementsPreviewManager(QMainWindow *parent);
+	virtual ~StreamElementsPreviewManager();
+
+protected:
+	virtual void OnObsExit();
+
+private:
+	QMainWindow *m_parent;
+	QObject *m_eventFilter;
+};

--- a/streamelements/StreamElementsWidgetManager.cpp
+++ b/streamelements/StreamElementsWidgetManager.cpp
@@ -7,16 +7,13 @@
 
 #include <QApplication>
 
-StreamElementsWidgetManager::StreamElementsWidgetManager(QMainWindow* parent) :
-	m_parent(parent),
-	m_nativeCentralWidget(nullptr)
+StreamElementsWidgetManager::StreamElementsWidgetManager(QMainWindow *parent)
+	: m_parent(parent), m_nativeCentralWidget(nullptr)
 {
 	assert(parent);
 }
 
-StreamElementsWidgetManager::~StreamElementsWidgetManager()
-{
-}
+StreamElementsWidgetManager::~StreamElementsWidgetManager() {}
 
 //
 // The QApplication::sendPostedEvents() and setMinimumSize() black
@@ -32,7 +29,7 @@ StreamElementsWidgetManager::~StreamElementsWidgetManager()
 // QApplication::sendPostedEvents().
 // Then we reset the new central widget minimum size to 0x0.
 //
-void StreamElementsWidgetManager::PushCentralWidget(QWidget* widget)
+void StreamElementsWidgetManager::PushCentralWidget(QWidget *widget)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
@@ -95,11 +92,8 @@ void StreamElementsWidgetManager::OnObsExit()
 }
 
 bool StreamElementsWidgetManager::AddDockWidget(
-	const char* const id,
-	const char* const title,
-	QWidget* const widget,
-	const Qt::DockWidgetArea area,
-	const Qt::DockWidgetAreas allowedAreas,
+	const char *const id, const char *const title, QWidget *const widget,
+	const Qt::DockWidgetArea area, const Qt::DockWidgetAreas allowedAreas,
 	const QDockWidget::DockWidgetFeatures features)
 {
 	assert(id);
@@ -114,14 +108,16 @@ bool StreamElementsWidgetManager::AddDockWidget(
 
 	class TrackedDockWidget : public QDockWidget {
 	public:
-		TrackedDockWidget(const QString &title, QWidget *parent = Q_NULLPTR,
-				   Qt::WindowFlags flags = Qt::WindowFlags())
+		TrackedDockWidget(const QString &title,
+				  QWidget *parent = Q_NULLPTR,
+				  Qt::WindowFlags flags = Qt::WindowFlags())
 			: QDockWidget(title, parent, flags)
 		{
 		}
 
 	protected:
-		virtual void resizeEvent(QResizeEvent *event) override {
+		virtual void resizeEvent(QResizeEvent *event) override
+		{
 			QDockWidget::resizeEvent(event);
 
 			AdviseHostUserInterfaceStateChanged();
@@ -157,33 +153,44 @@ bool StreamElementsWidgetManager::AddDockWidget(
 
 	std::string savedId = id;
 
-	QObject::connect(dock, &QDockWidget::dockLocationChanged, [savedId, dock, this](Qt::DockWidgetArea area) {
-		std::lock_guard<std::recursive_mutex> guard(m_mutex);
+	QObject::connect(
+		dock, &QDockWidget::dockLocationChanged,
+		[savedId, dock, this](Qt::DockWidgetArea area) {
+			std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-		if (!m_dockWidgets.count(savedId)) {
-			return;
-		}
+			if (!m_dockWidgets.count(savedId)) {
+				return;
+			}
 
-		m_dockWidgetAreas[savedId] = area;
+			m_dockWidgetAreas[savedId] = area;
 
-		QtPostTask([](void*) -> void {
-			StreamElementsGlobalStateManager::GetInstance()->PersistState();
-		}, nullptr);
-	});
+			QtPostTask(
+				[](void *) -> void {
+					StreamElementsGlobalStateManager::
+						GetInstance()
+							->PersistState();
+				},
+				nullptr);
+		});
 
 	QObject::connect(dock, &QDockWidget::visibilityChanged, [this]() {
 		std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-		QtPostTask([](void*) -> void {
-			StreamElementsGlobalStateManager::GetInstance()->GetMenuManager()->Update();
-			StreamElementsGlobalStateManager::GetInstance()->PersistState();
-		}, nullptr);
+		QtPostTask(
+			[](void *) -> void {
+				StreamElementsGlobalStateManager::GetInstance()
+					->GetMenuManager()
+					->Update();
+				StreamElementsGlobalStateManager::GetInstance()
+					->PersistState();
+			},
+			nullptr);
 	});
 
 	return true;
 }
 
-bool StreamElementsWidgetManager::ToggleWidgetFloatingStateById(const char* const id)
+bool StreamElementsWidgetManager::ShowWidgetById(const char *const id)
 {
 	assert(id);
 
@@ -193,14 +200,47 @@ bool StreamElementsWidgetManager::ToggleWidgetFloatingStateById(const char* cons
 		return false;
 	}
 
-	QDockWidget* dock = m_dockWidgets[id];
+	QDockWidget *dock = m_dockWidgets[id];
+
+	dock->setVisible(true);
+}
+
+bool StreamElementsWidgetManager::HideWidgetById(const char *const id)
+{
+	assert(id);
+
+	std::lock_guard<std::recursive_mutex> guard(m_mutex);
+
+	if (!m_dockWidgets.count(id)) {
+		return false;
+	}
+
+	QDockWidget *dock = m_dockWidgets[id];
+
+	dock->setVisible(false);
+}
+
+bool StreamElementsWidgetManager::ToggleWidgetFloatingStateById(
+	const char *const id)
+{
+	assert(id);
+
+	std::lock_guard<std::recursive_mutex> guard(m_mutex);
+
+	if (!m_dockWidgets.count(id)) {
+		return false;
+	}
+
+	QDockWidget *dock = m_dockWidgets[id];
 
 	dock->setFloating(!dock->isFloating());
 
 	return true;
 }
 
-bool StreamElementsWidgetManager::SetWidgetDimensionsById(const char* const id, const int width, const int height)
+bool StreamElementsWidgetManager::SetWidgetDimensionsById(const char *const id,
+							  const int width,
+							  const int height)
 {
 	assert(id);
 
@@ -210,7 +250,7 @@ bool StreamElementsWidgetManager::SetWidgetDimensionsById(const char* const id, 
 		return false;
 	}
 
-	QDockWidget* dock = m_dockWidgets[id];
+	QDockWidget *dock = m_dockWidgets[id];
 
 	if (!dock->isFloating() || !dock->window()) {
 		return false;
@@ -239,7 +279,9 @@ bool StreamElementsWidgetManager::SetWidgetDimensionsById(const char* const id, 
 	return true;
 }
 
-bool StreamElementsWidgetManager::SetWidgetPositionById(const char* const id, const int left, const int top)
+bool StreamElementsWidgetManager::SetWidgetPositionById(const char *const id,
+							const int left,
+							const int top)
 {
 	assert(id);
 
@@ -249,7 +291,7 @@ bool StreamElementsWidgetManager::SetWidgetPositionById(const char* const id, co
 		return false;
 	}
 
-	QDockWidget* dock = m_dockWidgets[id];
+	QDockWidget *dock = m_dockWidgets[id];
 
 	if (!dock->isFloating() || !dock->window()) {
 		return false;
@@ -270,7 +312,7 @@ bool StreamElementsWidgetManager::SetWidgetPositionById(const char* const id, co
 	return true;
 }
 
-bool StreamElementsWidgetManager::RemoveDockWidget(const char* const id)
+bool StreamElementsWidgetManager::RemoveDockWidget(const char *const id)
 {
 	assert(id);
 
@@ -280,7 +322,7 @@ bool StreamElementsWidgetManager::RemoveDockWidget(const char* const id)
 		return false;
 	}
 
-	QDockWidget* dock = m_dockWidgets[id];
+	QDockWidget *dock = m_dockWidgets[id];
 
 	m_dockWidgets.erase(id);
 	m_dockWidgetAreas.erase(id);
@@ -292,7 +334,8 @@ bool StreamElementsWidgetManager::RemoveDockWidget(const char* const id)
 	return true;
 }
 
-void StreamElementsWidgetManager::GetDockWidgetIdentifiers(std::vector<std::string>& result)
+void StreamElementsWidgetManager::GetDockWidgetIdentifiers(
+	std::vector<std::string> &result)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
@@ -301,7 +344,7 @@ void StreamElementsWidgetManager::GetDockWidgetIdentifiers(std::vector<std::stri
 	}
 }
 
-QDockWidget* StreamElementsWidgetManager::GetDockWidget(const char* const id)
+QDockWidget *StreamElementsWidgetManager::GetDockWidget(const char *const id)
 {
 	assert(id);
 
@@ -314,19 +357,21 @@ QDockWidget* StreamElementsWidgetManager::GetDockWidget(const char* const id)
 	return m_dockWidgets[id];
 }
 
-StreamElementsWidgetManager::DockWidgetInfo* StreamElementsWidgetManager::GetDockWidgetInfo(const char* const id)
+StreamElementsWidgetManager::DockWidgetInfo *
+StreamElementsWidgetManager::GetDockWidgetInfo(const char *const id)
 {
 	assert(id);
 
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-	QDockWidget* dockWidget = GetDockWidget(id);
+	QDockWidget *dockWidget = GetDockWidget(id);
 
 	if (!dockWidget) {
 		return nullptr;
 	}
 
-	StreamElementsWidgetManager::DockWidgetInfo* result = new StreamElementsWidgetManager::DockWidgetInfo();
+	StreamElementsWidgetManager::DockWidgetInfo *result =
+		new StreamElementsWidgetManager::DockWidgetInfo();
 
 	result->m_widget = dockWidget->widget();
 
@@ -337,8 +382,7 @@ StreamElementsWidgetManager::DockWidgetInfo* StreamElementsWidgetManager::GetDoc
 	if (dockWidget->isFloating()) {
 		result->m_dockingArea = "floating";
 	} else {
-		switch (m_dockWidgetAreas[id])
-		{
+		switch (m_dockWidgetAreas[id]) {
 		case Qt::LeftDockWidgetArea:
 			result->m_dockingArea = "left";
 			break;
@@ -361,7 +405,7 @@ StreamElementsWidgetManager::DockWidgetInfo* StreamElementsWidgetManager::GetDoc
 	return result;
 }
 
-void StreamElementsWidgetManager::SerializeDockingWidgets(std::string& output)
+void StreamElementsWidgetManager::SerializeDockingWidgets(std::string &output)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
@@ -370,19 +414,18 @@ void StreamElementsWidgetManager::SerializeDockingWidgets(std::string& output)
 	SerializeDockingWidgets(root);
 
 	// Convert data to JSON
-	CefString jsonString =
-		CefWriteJSON(root, JSON_WRITER_DEFAULT);
+	CefString jsonString = CefWriteJSON(root, JSON_WRITER_DEFAULT);
 
 	output = jsonString.ToString();
 }
 
-void StreamElementsWidgetManager::DeserializeDockingWidgets(std::string& input)
+void StreamElementsWidgetManager::DeserializeDockingWidgets(std::string &input)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
 	// Convert JSON string to CefValue
-	CefRefPtr<CefValue> root =
-		CefParseJSON(CefString(input), JSON_PARSER_ALLOW_TRAILING_COMMAS);
+	CefRefPtr<CefValue> root = CefParseJSON(
+		CefString(input), JSON_PARSER_ALLOW_TRAILING_COMMAS);
 
 	DeserializeDockingWidgets(root);
 }
@@ -410,7 +453,8 @@ void StreamElementsWidgetManager::RestoreDockWidgetsGeometry()
 
 	for (auto iter : m_dockWidgetSavedMinSize) {
 		if (m_dockWidgets.count(iter.first)) {
-			maxSize[iter.first] = m_dockWidgets[iter.first]->maximumSize();
+			maxSize[iter.first] =
+				m_dockWidgets[iter.first]->maximumSize();
 
 			m_dockWidgets[iter.first]->setMinimumSize(iter.second);
 			m_dockWidgets[iter.first]->setMaximumSize(iter.second);
@@ -422,7 +466,8 @@ void StreamElementsWidgetManager::RestoreDockWidgetsGeometry()
 	for (auto iter : m_dockWidgetSavedMinSize) {
 		if (m_dockWidgets.count(iter.first)) {
 			m_dockWidgets[iter.first]->setMinimumSize(QSize(0, 0));
-			m_dockWidgets[iter.first]->setMaximumSize(maxSize[iter.first]);
+			m_dockWidgets[iter.first]->setMaximumSize(
+				maxSize[iter.first]);
 		}
 	}
 

--- a/streamelements/StreamElementsWidgetManager.hpp
+++ b/streamelements/StreamElementsWidgetManager.hpp
@@ -67,7 +67,10 @@ public:
 		const Qt::DockWidgetAreas allowedAreas = Qt::AllDockWidgetAreas,
 		const QDockWidget::DockWidgetFeatures features = QDockWidget::AllDockWidgetFeatures);
 
-	virtual bool ToggleWidgetFloatingStateById(const char* const id);
+	virtual bool ShowWidgetById(const char *const id);
+	virtual bool HideWidgetById(const char *const id);
+
+	virtual bool ToggleWidgetFloatingStateById(const char *const id);
 
 	virtual bool SetWidgetDimensionsById(const char* const id, const int width, const int height);
 	virtual bool SetWidgetPositionById(const char* const id, const int left, const int top);


### PR DESCRIPTION
Add API Methods:

  * setDockingWidgetUrlById
  * showDockingWidgetById
  * hideDockingWidgetById

Add Events:

  * hostActiveSceneItemAdded
  * hostActiveSceneItemRemoved
  * hostActiveSceneItemTransformed
  * hostActiveSceneItemsOrderChanged
  * hostActiveSceneItemSelected
  * hostActiveSceneItemUnselected
  * hostActiveSceneItemPropertiesChanged
  * hostActiveSceneItemSettingsChanged
  * hostActiveSceneItemRenamed
  * hostVideoPreviewMouseDoubleClicked
  * hostCurrentSceneItemsListMouseDoubleClicked
  * hostBeforeFocusChange

Resolve Issues:

  * `broadcastMessage` and `broadcastEvent` API methods can now be
    called from non-browser context (example: auxiliary menu item)

  * Resolve deadlock when removing multiple browser sources at once