### PR TITLE
obs-browser: API 1.24: scene item actions support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,10 @@ set(obs-browser_SOURCES
 	streamelements/StreamElementsBackupManager.cpp
 	streamelements/StreamElementsCleanupManager.cpp
 	streamelements/StreamElementsPreviewManager.cpp
+	streamelements/StreamElementsSceneItemsMonitor.cpp
+	streamelements/StreamElementsDeferredExecutive.cpp
+	streamelements/StreamElementsRemoteIconLoader.cpp
+	streamelements/StreamElementsScenesListWidgetManager.cpp
 	streamelements/deps/zip/zip.c
 	streamelements/deps/server/NamedPipesServer.cpp
 	streamelements/deps/server/NamedPipesServerClientHandler.cpp
@@ -232,6 +236,10 @@ set(obs-browser_HEADERS
 	streamelements/StreamElementsBackupManager.hpp
 	streamelements/StreamElementsCleanupManager.hpp
 	streamelements/StreamElementsPreviewManager.hpp
+	streamelements/StreamElementsSceneItemsMonitor.hpp
+	streamelements/StreamElementsDeferredExecutive.hpp
+	streamelements/StreamElementsRemoteIconLoader.hpp
+	streamelements/StreamElementsScenesListWidgetManager.hpp
 	streamelements/deps/zip/zip.h
 	streamelements/deps/zip/miniz.h
 	streamelements/deps/moodycamel/concurrentqueue.h

--- a/streamelements/StreamElementsAnalyticsEventsManager.cpp
+++ b/streamelements/StreamElementsAnalyticsEventsManager.cpp
@@ -81,7 +81,7 @@ void StreamElementsAnalyticsEventsManager::AddRawEvent(const char* eventName, js
 
 	if (!synchronous) {
 		Enqueue([=]() {
-			http_client_request_headers_t headers;
+			http_client_headers_t headers;
 
 			headers.emplace(
 				std::make_pair<std::string, std::string>(
@@ -97,7 +97,7 @@ void StreamElementsAnalyticsEventsManager::AddRawEvent(const char* eventName, js
 		});
 	}
 	else {
-		http_client_request_headers_t headers;
+		http_client_headers_t headers;
 
 		headers.emplace(
 			std::make_pair<std::string, std::string>(

--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -16,6 +16,9 @@
 
 #include <codecvt>
 
+std::shared_ptr<StreamElementsApiMessageHandler::InvokeHandler>
+	StreamElementsApiMessageHandler::InvokeHandler::s_singleton = nullptr;
+
 /* Incoming messages from renderer process */
 const char *MSG_ON_CONTEXT_CREATED =
 	"CefRenderProcessHandler::OnContextCreated";
@@ -1181,6 +1184,66 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 				->RemoveObsCurrentSceneItemsByIds(
 					args->GetValue(0), result);
 		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("invokeCurrentSceneItemDefaultActionById");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetObsSceneManager()
+				->InvokeCurrentSceneItemDefaultActionById(
+					args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("invokeCurrentSceneItemDefaultContextMenuById");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetObsSceneManager()
+				->InvokeCurrentSceneItemDefaultContextMenuById(
+					args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("setCurrentSceneItemsAuxiliaryActions");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetObsSceneManager()
+				->DeserializeSceneItemsAuxiliaryActions(
+					args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("getCurrentSceneItemsAuxiliaryActions");
+	{
+		StreamElementsGlobalStateManager::GetInstance()
+			->GetObsSceneManager()
+			->SerializeSceneItemsAuxiliaryActions(result);
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("setScenesAuxiliaryActions");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetObsSceneManager()
+				->DeserializeScenesAuxiliaryActions(
+					args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("getScenesAuxiliaryActions");
+	{
+		StreamElementsGlobalStateManager::GetInstance()
+			->GetObsSceneManager()
+			->SerializeScenesAuxiliaryActions(result);
 	}
 	API_HANDLER_END();
 

--- a/streamelements/StreamElementsApiMessageHandler.hpp
+++ b/streamelements/StreamElementsApiMessageHandler.hpp
@@ -2,43 +2,54 @@
 
 #include "StreamElementsBrowserMessageHandler.hpp"
 
+#include <mutex>
 #include <functional>
 
 class StreamElementsApiMessageHandler
-	:
-	public StreamElementsBrowserMessageHandler
-{
+	: public StreamElementsBrowserMessageHandler {
 public:
 	StreamElementsApiMessageHandler() {}
 	virtual ~StreamElementsApiMessageHandler() {}
 
 public:
-	virtual bool OnProcessMessageReceived(
-		CefRefPtr<CefBrowser> browser,
+	virtual bool
+	OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 #if CHROME_VERSION_BUILD >= 3770
-		CefRefPtr<CefFrame> frame,
+				 CefRefPtr<CefFrame> frame,
 #endif
-		CefProcessId source_process,
-		CefRefPtr<CefProcessMessage> message,
-		const long cefClientId) override;
+				 CefProcessId source_process,
+				 CefRefPtr<CefProcessMessage> message,
+				 const long cefClientId) override;
 
-	void setInitialHiddenState(bool isHidden) { m_initialHiddenState = isHidden; }
+	void setInitialHiddenState(bool isHidden)
+	{
+		m_initialHiddenState = isHidden;
+	}
 
 protected:
 	virtual void RegisterIncomingApiCallHandlers();
 
-	typedef void (*incoming_call_handler_t)(StreamElementsApiMessageHandler*, CefRefPtr<CefProcessMessage> message, CefRefPtr<CefListValue> args, CefRefPtr<CefValue>& result, CefRefPtr<CefBrowser> browser, void (*complete)(void*), void* context);
+	typedef void (*incoming_call_handler_t)(
+		StreamElementsApiMessageHandler *,
+		CefRefPtr<CefProcessMessage> message,
+		CefRefPtr<CefListValue> args, CefRefPtr<CefValue> &result,
+		CefRefPtr<CefBrowser> browser, void (*complete)(void *),
+		void *context);
 
-	void RegisterIncomingApiCallHandler(std::string id, incoming_call_handler_t handler);
+	void RegisterIncomingApiCallHandler(std::string id,
+					    incoming_call_handler_t handler);
 
 private:
 	std::map<std::string, incoming_call_handler_t> m_apiCallHandlers;
 	bool m_initialHiddenState = false;
 
-	void RegisterIncomingApiCallHandlersInternal(CefRefPtr<CefBrowser> browser);
+	void
+	RegisterIncomingApiCallHandlersInternal(CefRefPtr<CefBrowser> browser);
 	void RegisterApiPropsInternal(CefRefPtr<CefBrowser> browser);
 	void DispatchHostReadyEventInternal(CefRefPtr<CefBrowser> browser);
-	void DispatchEventInternal(CefRefPtr<CefBrowser> browser, std::string event, std::string eventArgsJson);
+	void DispatchEventInternal(CefRefPtr<CefBrowser> browser,
+				   std::string event,
+				   std::string eventArgsJson);
 
 public:
 	class InvokeHandler;
@@ -50,10 +61,36 @@ public:
 class StreamElementsApiMessageHandler::InvokeHandler
 	: public StreamElementsApiMessageHandler {
 public:
-	InvokeHandler() { RegisterIncomingApiCallHandlers(); }
+	InvokeHandler()
+	{
+		RegisterIncomingApiCallHandlers();
+	}
+
+public:
 	~InvokeHandler() {}
 
+	static std::shared_ptr<StreamElementsApiMessageHandler::InvokeHandler> GetInstance()
+	{
+		static std::mutex mutex;
+
+		if (!s_singleton) {
+			std::lock_guard<std::mutex> guard(mutex);
+
+			if (!s_singleton) {
+				s_singleton = std::make_shared<
+					StreamElementsApiMessageHandler::
+						InvokeHandler>();
+			}
+		}
+
+		return s_singleton;
+	}
+
+public:
 	bool
 	InvokeApiCallAsync(std::string invoke, CefRefPtr<CefListValue> args,
 			   std::function<void(CefRefPtr<CefValue>)> callback);
+
+private:
+	static std::shared_ptr<StreamElementsApiMessageHandler::InvokeHandler> s_singleton;
 };

--- a/streamelements/StreamElementsConfig.hpp
+++ b/streamelements/StreamElementsConfig.hpp
@@ -132,6 +132,52 @@ public:
 		SaveConfig();
 	}
 
+	std::string GetSceneItemsAuxActionsConfig()
+	{
+		const char *value = config_get_string(
+			StreamElementsConfig::GetInstance()->GetConfig(),
+			"Startup", "AuxSourcesActions");
+
+		if (!!value)
+			return value;
+		else
+			return "[]";
+	}
+
+	void SetSceneItemsAuxActionsConfig(std::string value)
+	{
+		config_set_string(
+			StreamElementsConfig::GetInstance()->GetConfig(),
+			"Startup", "AuxSourcesActions", value.c_str());
+
+		SaveConfig();
+	}
+
+	std::string GetScenesAuxActionsConfig()
+	{
+		const char *value = config_get_string(
+			StreamElementsConfig::GetInstance()->GetConfig(),
+			"Startup", "AuxScenesActions");
+
+		if (!!value)
+			return value;
+		else
+			return "[]";
+	}
+
+	void SetScenesAuxActionsConfig(std::string value)
+	{
+		config_set_string(
+			StreamElementsConfig::GetInstance()->GetConfig(),
+			"Startup", "AuxScenesActions", value.c_str());
+
+		SaveConfig();
+	}
+
+	bool IsOnBoardingMode() {
+		return (GetStartupFlags() & STARTUP_FLAGS_ONBOARDING_MODE) != 0;
+	}
+
 private:
 	config_t* m_config = nullptr;
 

--- a/streamelements/StreamElementsDeferredExecutive.cpp
+++ b/streamelements/StreamElementsDeferredExecutive.cpp
@@ -1,0 +1,46 @@
+#include "StreamElementsDeferredExecutive.hpp"
+#include "StreamElementsUtils.hpp"
+
+StreamElementsDeferredExecutive::StreamElementsDeferredExecutive() {}
+
+StreamElementsDeferredExecutive::~StreamElementsDeferredExecutive()
+{
+	Cancel();
+}
+
+void StreamElementsDeferredExecutive::Cancel()
+{
+	if (!m_timer)
+		return;
+
+	std::lock_guard<std::recursive_mutex> guard(m_mutex);
+
+	m_timer->stop();
+	m_timer->deleteLater();
+	m_timer = nullptr;
+}
+
+void StreamElementsDeferredExecutive::Signal(std::function<void()> callback,
+					     int delayMilliseconds)
+{
+	Cancel();
+
+	m_callback = callback;
+
+	m_timer = new QTimer();
+	m_timer->moveToThread(qApp->thread());
+	m_timer->setSingleShot(true);
+	m_timer->setInterval(delayMilliseconds);
+
+	QObject::connect(m_timer, &QTimer::timeout, [&]() {
+		std::lock_guard<std::recursive_mutex> guard(m_mutex);
+
+		m_timer->deleteLater();
+		m_timer = nullptr;
+
+		m_callback();
+	});
+
+	QMetaObject::invokeMethod(m_timer, "start", Qt::QueuedConnection,
+				  Q_ARG(int, 0));
+}

--- a/streamelements/StreamElementsDeferredExecutive.hpp
+++ b/streamelements/StreamElementsDeferredExecutive.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QTimer>
+
+#include <mutex>
+
+class StreamElementsDeferredExecutive
+{
+public:
+	StreamElementsDeferredExecutive();
+	~StreamElementsDeferredExecutive();
+
+public:
+	void Cancel();
+	void Signal(std::function<void()> callback, int delayMilliseconds);
+
+private:
+	QTimer *m_timer = nullptr;
+	std::function<void()> m_callback;
+	std::recursive_mutex m_mutex;
+};

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -605,6 +605,10 @@ void StreamElementsGlobalStateManager::StartOnBoardingUI(UiModifier uiModifier)
 	QtPostTask(
 		[](void *) -> void {
 			StreamElementsGlobalStateManager::GetInstance()
+				->GetObsSceneManager()
+				->Reset();
+
+			StreamElementsGlobalStateManager::GetInstance()
 				->GetMenuManager()
 				->Update();
 			StreamElementsGlobalStateManager::GetInstance()
@@ -661,6 +665,10 @@ void StreamElementsGlobalStateManager::SwitchToOBSStudio()
 			StreamElementsConfig::GetInstance()->SetStartupFlags(
 				StreamElementsConfig::
 					STARTUP_FLAGS_ONBOARDING_MODE);
+
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetObsSceneManager()
+				->Reset();
 
 			GetMenuManager()->Update();
 		}

--- a/streamelements/StreamElementsHttpClient.cpp
+++ b/streamelements/StreamElementsHttpClient.cpp
@@ -22,7 +22,7 @@ void StreamElementsHttpClient::DeserializeHttpRequestText(
 		std::string url =
 			d->HasKey("url") ? d->GetString("url") : "";
 
-		http_client_request_headers_t request_headers;
+		http_client_headers_t request_headers;
 
 		if (d->HasKey("headers") && d->GetType("headers") == VTYPE_DICTIONARY) {
 			CefRefPtr<CefDictionaryValue> h = d->GetDictionary("headers");

--- a/streamelements/StreamElementsMenuManager.hpp
+++ b/streamelements/StreamElementsMenuManager.hpp
@@ -16,34 +16,6 @@ class StreamElementsMenuManager
 private:
 	enum aux_menu_item_type_t { Command, Separator, Container };
 
-	class aux_menu_item_t
-	{
-	public:
-		enum aux_menu_item_type_t type = Command;
-		std::string title;
-		std::string apiMethod;
-		CefRefPtr<CefListValue> apiArgs;
-		std::vector<aux_menu_item_t> items;
-
-		aux_menu_item_t() {}
-		~aux_menu_item_t() {}
-
-		aux_menu_item_t(const aux_menu_item_t& o) {
-			type = o.type;
-			title = o.title;
-			apiMethod = o.apiMethod;
-			if (o.apiArgs) {
-				apiArgs = o.apiArgs->Copy();
-			}
-			if (o.items.size()) {
-				items.resize(o.items.size());
-
-				std::copy(o.items.begin(), o.items.end(),
-					  items.begin());
-			}
-		}
-	};
-
 public:
 	StreamElementsMenuManager(QMainWindow* parent);
 	virtual ~StreamElementsMenuManager();
@@ -63,20 +35,7 @@ protected:
 	void LoadConfig();
 
 private:
-	void AddAuxiliaryMenuItems(QMenu *menu,
-				   std::vector<aux_menu_item_t> &auxMenuItems,
-				   bool requestSeparator);
-
-	bool DeserializeAuxiliaryMenuItemsInternal(
-		CefRefPtr<CefValue> input,
-		std::vector<aux_menu_item_t> &result);
-
-	CefRefPtr<CefListValue> SerializeAuxiliaryMenuItemsInternal(
-		std::vector<aux_menu_item_t> &items);
-
-private:
 	QMainWindow* m_mainWindow;
 	QMenu* m_menu;
-	std::vector<aux_menu_item_t> m_auxMenuItems;
-	StreamElementsApiMessageHandler::InvokeHandler *m_handler;
+	CefRefPtr<CefValue> m_auxMenuItems = CefValue::Create();
 };

--- a/streamelements/StreamElementsObsSceneManager.hpp
+++ b/streamelements/StreamElementsObsSceneManager.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "StreamElementsSceneItemsMonitor.hpp"
+#include "StreamElementsScenesListWidgetManager.hpp"
+
 #include "cef-headers.hpp"
 
 #include <obs.h>
@@ -10,13 +13,27 @@
 
 #include <mutex>
 
-class StreamElementsObsSceneManager
-{
+class StreamElementsObsSceneManager {
 public:
-	StreamElementsObsSceneManager(QMainWindow* parent);
+	StreamElementsObsSceneManager(QMainWindow *parent);
 	virtual ~StreamElementsObsSceneManager();
 
 public:
+	void Reset()
+	{
+		DeserializeSceneItemsAuxiliaryActions(CefValue::Create(),
+						      CefValue::Create());
+
+		DeserializeScenesAuxiliaryActions(CefValue::Create(),
+						  CefValue::Create());
+
+		if (m_sceneItemsMonitor)
+			m_sceneItemsMonitor->Update();
+
+		if (m_scenesWidgetManager)
+			m_scenesWidgetManager->Update();
+	}
+
 	/* Sources */
 
 	void SerializeInputSourceClasses(CefRefPtr<CefValue> &output);
@@ -26,9 +43,8 @@ public:
 
 	/* Scene items */
 
-	void DeserializeObsBrowserSource(
-		CefRefPtr<CefValue>& input,
-		CefRefPtr<CefValue>& output);
+	void DeserializeObsBrowserSource(CefRefPtr<CefValue> &input,
+					 CefRefPtr<CefValue> &output);
 
 	void DeserializeObsGameCaptureSource(CefRefPtr<CefValue> &input,
 					     CefRefPtr<CefValue> &output);
@@ -42,8 +58,7 @@ public:
 	void DeserializeObsSceneItemGroup(CefRefPtr<CefValue> &input,
 					  CefRefPtr<CefValue> &output);
 
-	void SerializeObsCurrentSceneItems(
-		CefRefPtr<CefValue>& output);
+	void SerializeObsCurrentSceneItems(CefRefPtr<CefValue> &output);
 
 	void RemoveObsCurrentSceneItemsByIds(CefRefPtr<CefValue> input,
 					     CefRefPtr<CefValue> &output);
@@ -53,6 +68,18 @@ public:
 
 	void UngroupObsCurrentSceneItemsByGroupId(CefRefPtr<CefValue> input,
 						  CefRefPtr<CefValue> &output);
+
+	void
+	InvokeCurrentSceneItemDefaultActionById(CefRefPtr<CefValue> input,
+						CefRefPtr<CefValue> &output);
+
+	void InvokeCurrentSceneItemDefaultContextMenuById(
+		CefRefPtr<CefValue> input, CefRefPtr<CefValue> &output);
+
+	void DeserializeSceneItemsAuxiliaryActions(CefRefPtr<CefValue> input,
+						   CefRefPtr<CefValue> &output);
+
+	void SerializeSceneItemsAuxiliaryActions(CefRefPtr<CefValue> &output);
 
 	/* Scenes */
 
@@ -72,6 +99,11 @@ public:
 	void SetObsScenePropertiesById(CefRefPtr<CefValue> input,
 				       CefRefPtr<CefValue> &output);
 
+	void DeserializeScenesAuxiliaryActions(CefRefPtr<CefValue> input,
+					       CefRefPtr<CefValue> &output);
+
+	void SerializeScenesAuxiliaryActions(CefRefPtr<CefValue> &output);
+
 	/* Scene collections */
 
 	void SerializeObsSceneCollections(CefRefPtr<CefValue> &output);
@@ -86,18 +118,16 @@ public:
 						 CefRefPtr<CefValue> &output);
 
 protected:
-	QMainWindow* mainWindow() { return m_parent; }
+	QMainWindow *mainWindow() { return m_parent; }
 
-	void ObsAddSourceInternal(
-		obs_source_t* parentScene,
-		obs_sceneitem_t* parentGroup,
-		const char* sourceId,
-		const char* sourceName,
-		obs_data_t* sourceSettings,
-		obs_data_t* sourceHotkeyData,
-		bool preferExistingSource,
-		obs_source_t** output_source,
-		obs_sceneitem_t** output_sceneitem);
+	void ObsAddSourceInternal(obs_source_t *parentScene,
+				  obs_sceneitem_t *parentGroup,
+				  const char *sourceId, const char *sourceName,
+				  obs_data_t *sourceSettings,
+				  obs_data_t *sourceHotkeyData,
+				  bool preferExistingSource,
+				  obs_source_t **output_source,
+				  obs_sceneitem_t **output_sceneitem);
 
 	void RefreshObsSceneItemsList();
 
@@ -107,9 +137,15 @@ protected:
 
 	std::string ObsGetUniqueSceneCollectionName(std::string name);
 
+private:
+	static void handle_obs_frontend_event(enum obs_frontend_event event,
+					      void *data);
+
 protected:
 	std::recursive_mutex m_mutex;
 
 private:
-	QMainWindow* m_parent;
+	QMainWindow *m_parent;
+	StreamElementsSceneItemsMonitor *m_sceneItemsMonitor = nullptr;
+	StreamElementsScenesListWidgetManager *m_scenesWidgetManager = nullptr;
 };

--- a/streamelements/StreamElementsRemoteIconLoader.cpp
+++ b/streamelements/StreamElementsRemoteIconLoader.cpp
@@ -1,0 +1,209 @@
+#include "StreamElementsRemoteIconLoader.hpp"
+
+#include <QCache>
+#include <QReadWriteLock>
+
+static class CachedPixmap : QObject {
+private:
+	QIcon m_icon;
+
+public:
+	CachedPixmap(QIcon icon) : m_icon(icon) {}
+	~CachedPixmap() {}
+
+	QIcon icon() { return m_icon; }
+};
+
+static QCache<QString, CachedPixmap> s_cache;
+QReadWriteLock s_cacheLock;
+
+static bool GetCached(const QString &key, QIcon &icon)
+{
+	bool result = false;
+
+	s_cacheLock.lockForRead();
+
+	CachedPixmap *object = s_cache.object(key);
+
+	if (object) {
+		icon = object->icon();
+
+		result = true;
+	}
+
+	s_cacheLock.unlock();
+
+	return result;
+}
+
+static void SetCached(const QString &key, const QIcon &icon)
+{
+	s_cacheLock.lockForWrite();
+
+	s_cache.insert(key, new CachedPixmap(icon));
+
+	s_cacheLock.unlock();
+}
+
+StreamElementsRemoteIconLoader::StreamElementsRemoteIconLoader(
+	setIcon_callback_t setIcon, const char *url, QPixmap *defaultPixmap,
+	bool requireQtPostTaskOnCached)
+	: m_setIcon(setIcon)
+{
+	if (url && *url) {
+		LoadUrlInternal(url, requireQtPostTaskOnCached);
+	} else {
+		if (defaultPixmap) {
+			this->AddRef();
+
+			QPixmap pixmap(16, 16);
+
+			if (defaultPixmap) {
+				pixmap = *defaultPixmap;
+			} else {
+				pixmap.fill(Qt::transparent);
+			}
+
+			if (!requireQtPostTaskOnCached) {
+				std::lock_guard<std::recursive_mutex> guard(
+					m_mutex);
+
+				if (!m_cancelled) {
+					m_setIcon(QIcon(pixmap));
+				}
+			} else {
+				this->AddRef();
+
+				QtPostTask([=]() {
+					std::lock_guard<std::recursive_mutex>
+						guard(m_mutex);
+
+					if (!m_cancelled) {
+						m_setIcon(QIcon(pixmap));
+					}
+
+					this->Release();
+				});
+			}
+		}
+	}
+}
+
+StreamElementsRemoteIconLoader::~StreamElementsRemoteIconLoader()
+{
+	Cancel();
+}
+
+CefRefPtr<StreamElementsRemoteIconLoader>
+StreamElementsRemoteIconLoader::Create(setIcon_callback_t setIcon,
+				       const char *url, QPixmap *defaultPixmap,
+				       bool requireQtPostTaskOnCached)
+{
+	return new StreamElementsRemoteIconLoader(setIcon, url, defaultPixmap,
+						  requireQtPostTaskOnCached);
+}
+
+void StreamElementsRemoteIconLoader::Cancel()
+{
+	std::lock_guard<std::recursive_mutex> guard(m_mutex);
+
+	m_cancelled = true;
+
+	if (m_task) {
+		// m_task->Cancel();
+
+		m_task = nullptr;
+	}
+
+	if (m_request) {
+		m_request->Cancel();
+
+		m_request = nullptr;
+	}
+}
+
+void StreamElementsRemoteIconLoader::LoadUrl(const char* url)
+{
+	LoadUrlInternal(url, true);
+}
+
+void StreamElementsRemoteIconLoader::LoadUrlInternal(
+	const char *url, bool requireQtPostTaskOnCached)
+{
+	if (!url)
+		return;
+
+	std::lock_guard<std::recursive_mutex> guard(m_mutex);
+
+	Cancel();
+
+	m_cancelled = false;
+
+	QString cacheKey(url);
+
+	QIcon cached;
+	if (GetCached(cacheKey, cached)) {
+		if (!requireQtPostTaskOnCached) {
+			if (!m_cancelled) {
+				m_setIcon(cached);
+			}
+		} else {
+			this->AddRef();
+
+			QtPostTask([this, cached]() {
+				std::lock_guard<std::recursive_mutex> guard(
+					m_mutex);
+
+				if (!m_cancelled) {
+					m_setIcon(cached);
+				}
+
+				this->Release();
+			});
+		}
+
+		return;
+	}
+
+	this->AddRef();
+
+	m_task = CefHttpGetAsync(
+		url,
+		[&](CefRefPtr<CefURLRequest> request) { m_request = request; },
+		[this, cacheKey](bool success, void *data, size_t len) {
+			std::lock_guard<std::recursive_mutex> guard(m_mutex);
+
+			if (m_request) {
+				m_request = nullptr;
+			}
+
+			m_task = nullptr;
+
+			if (success && !m_cancelled) {
+				QByteArray buffer = QByteArray::fromRawData(
+					(char *)data, len);
+				QPixmap pixmap;
+				if (pixmap.loadFromData(buffer)) {
+					QIcon icon(pixmap);
+
+					SetCached(cacheKey, icon);
+
+					this->AddRef();
+
+					QtPostTask([this, icon]() {
+						std::lock_guard<
+							std::recursive_mutex>
+							guard(m_mutex);
+
+						if (!m_cancelled) {
+							m_setIcon(icon);
+						}
+
+						this->Release();
+					});
+				}
+			}
+
+			this->Release();
+		});
+}

--- a/streamelements/StreamElementsRemoteIconLoader.hpp
+++ b/streamelements/StreamElementsRemoteIconLoader.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "StreamElementsUtils.hpp"
+#include <QIcon>
+#include <QPixmap>
+
+#include <functional>
+
+static class StreamElementsRemoteIconLoader : public CefBaseRefCounted {
+public:
+	typedef std::function<void(const QIcon)> setIcon_callback_t;
+
+public:
+	static CefRefPtr<StreamElementsRemoteIconLoader>
+	Create(setIcon_callback_t setIcon, const char *url = nullptr,
+	       QPixmap *defaultPixmap = nullptr, bool requireQtPostTaskOnCached = true);
+
+private:
+	StreamElementsRemoteIconLoader(setIcon_callback_t setIcon,
+				       const char *url, QPixmap *defaultPixmap,
+				       bool requireQtPostTaskOnCached);
+	~StreamElementsRemoteIconLoader();
+
+	void LoadUrlInternal(const char *url, bool requireQtPostTaskOnCached);
+
+public:
+	void Cancel();
+	void LoadUrl(const char *url);
+
+private:
+	std::recursive_mutex m_mutex;
+	CefRefPtr<CefURLRequest> m_request = nullptr;
+	CefRefPtr<CefCancelableTask> m_task = nullptr;
+	setIcon_callback_t m_setIcon;
+	bool m_cancelled = false;
+
+	IMPLEMENT_REFCOUNTING(StreamElementsRemoteIconLoader);
+};

--- a/streamelements/StreamElementsSceneItemsMonitor.cpp
+++ b/streamelements/StreamElementsSceneItemsMonitor.cpp
@@ -1,0 +1,950 @@
+#include "StreamElementsSceneItemsMonitor.hpp"
+#include "StreamElementsUtils.hpp"
+#include "StreamElementsApiMessageHandler.hpp"
+#include "StreamElementsRemoteIconLoader.hpp"
+#include "StreamElementsConfig.hpp"
+
+#include <obs.h>
+#include <obs-frontend-api.h>
+
+#include <string>
+#include <vector>
+
+#include <QDockWidget>
+#include <QLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QLabel>
+#include <QMenu>
+#include <QContextMenuEvent>
+
+static const char *ITEM_PRIVATE_DATA_KEY_UI_AUXILIARY_ACTIONS =
+	"streamelements_aux_ui_actions";
+
+static const char *ITEM_PRIVATE_DATA_KEY_UI_ICON = "streamelements_ui_icon";
+
+static const char *ITEM_PRIVATE_DATA_KEY_UI_DEFAULT_ACTION =
+	"streamelements_ui_default_action";
+
+static const char *ITEM_PRIVATE_DATA_KEY_UI_CONTEXT_MENU =
+	"streamelements_ui_context_menu";
+
+static const char *ITEM_PRIVATE_DATA_KEY_APPDATA = "streamelements_app_data";
+
+static const char *WIDGET_PROP_DEFAULT_ACTION_BYPASS_COUNT =
+	"streamelements_default_action_bypass_count";
+
+static const char *WIDGET_PROP_SCENE_ITEM_ID = "streamelements_scene_item_id";
+
+static obs_sceneitem_t *FindSceneItemByIdAddRef(std::string id)
+{
+	if (!id.size())
+		return nullptr;
+
+	struct local_context {
+		const void *searchPtr = nullptr;
+		obs_sceneitem_t *sceneitem = nullptr;
+	};
+
+	local_context context;
+
+	context.searchPtr = GetPointerFromId(id.c_str());
+
+	if (!context.searchPtr)
+		return nullptr;
+
+	obs_source_t *currentScene = obs_frontend_get_current_scene();
+
+	obs_scene_t *scene = obs_scene_from_source(
+		currentScene); // does not increment refcount
+
+	ObsSceneEnumAllItems(scene, [&](obs_sceneitem_t *sceneitem) {
+		if (context.searchPtr == sceneitem) {
+			context.sceneitem = sceneitem;
+
+			return false;
+		}
+
+		return true;
+	});
+
+	obs_source_release(currentScene);
+
+	return context.sceneitem;
+}
+
+static obs_sceneitem_t *GetObjectSceneItemAddRef(QObject *o)
+{
+	QVariant sceneItemIdVariant = o->property(WIDGET_PROP_SCENE_ITEM_ID);
+
+	return sceneItemIdVariant.isValid()
+		       ? FindSceneItemByIdAddRef(
+				 sceneItemIdVariant.toString().toStdString())
+		       : nullptr;
+}
+
+static class SceneItemsLocalEventFilter : public QObject {
+private:
+	QMainWindow *m_mainWindow;
+	StreamElementsSceneItemsMonitor *m_monitor;
+
+public:
+	SceneItemsLocalEventFilter(QMainWindow *mainWindow,
+				   StreamElementsSceneItemsMonitor *monitor)
+		: m_mainWindow(mainWindow), m_monitor(monitor)
+	{
+	}
+
+	~SceneItemsLocalEventFilter() {}
+
+	virtual bool eventFilter(QObject *target, QEvent *e) override
+	{
+		if (!target)
+			return false;
+
+		if (e->type() != QEvent::MouseButtonDblClick &&
+		    e->type() != QEvent::ContextMenu)
+			return false;
+
+		QMouseEvent *mouse = dynamic_cast<QMouseEvent *>(e);
+		QContextMenuEvent *contextMenu =
+			dynamic_cast<QContextMenuEvent *>(e);
+
+		if (!mouse && !contextMenu)
+			return false;
+
+		/* Make sure events belong to QListView item widgets */
+		if (!target->parent() ||
+		    !m_monitor->GetSceneItemsListView()->viewport() ||
+		    target->parent() !=
+			    m_monitor->GetSceneItemsListView()->viewport())
+			return false;
+
+		QWidget *o = dynamic_cast<QWidget *>(target);
+		/*
+		QWidget *o = m_monitor->GetWidgetAtLocalPosition(
+			mouse ? mouse->localPos() : contextMenu->pos());*/
+
+		if (!o)
+			return false;
+
+		if (e->type() == QEvent::MouseButtonDblClick) {
+			QVariant bypassValue = o->property(
+				WIDGET_PROP_DEFAULT_ACTION_BYPASS_COUNT);
+			if (bypassValue.isValid()) {
+				if (bypassValue.value<int>() > 0) {
+					bypassValue.setValue<int>(
+						bypassValue.value<int>() - 1);
+
+					o->setProperty(
+						WIDGET_PROP_DEFAULT_ACTION_BYPASS_COUNT,
+						bypassValue);
+
+					return false;
+				}
+			}
+
+			obs_sceneitem_t *scene_item =
+				GetObjectSceneItemAddRef(o);
+
+			if (!scene_item)
+				return false;
+
+			bool handled = false;
+
+			CefRefPtr<CefValue> value =
+				StreamElementsSceneItemsMonitor::
+					GetSceneItemDefaultAction(scene_item);
+
+			if (value->GetType() == VTYPE_DICTIONARY) {
+				auto defaultAction = [this, scene_item]() {
+					if (!scene_item)
+						return;
+
+					this->m_monitor
+						->InvokeCurrentSceneItemDefaultAction(
+							scene_item);
+				};
+
+				auto defaultContextMenu = [this, scene_item]() {
+					if (!scene_item)
+						return;
+
+					this->m_monitor
+						->InvokeCurrentSceneItemDefaultAction(
+							scene_item);
+				};
+
+				handled = DeserializeAndInvokeAction(
+					value, defaultAction,
+					defaultContextMenu);
+
+				if (scene_item)
+					obs_sceneitem_release(scene_item);
+			}
+
+			return handled;
+		}
+
+		if (e->type() == QEvent::ContextMenu) {
+			obs_sceneitem_t *scene_item =
+				GetObjectSceneItemAddRef(o);
+
+			if (!scene_item)
+				return false;
+
+			CefRefPtr<CefValue> value =
+				StreamElementsSceneItemsMonitor::
+					GetSceneItemContextMenu(scene_item);
+
+			bool handled = false;
+
+			if (value->GetType() == VTYPE_LIST &&
+			    value->GetList()->GetSize()) {
+				auto defaultAction = [this, scene_item]() {
+					if (!scene_item)
+						return;
+
+					this->m_monitor
+						->InvokeCurrentSceneItemDefaultAction(
+							scene_item);
+				};
+
+				auto defaultContextMenu = [this, scene_item]() {
+					if (!scene_item)
+						return;
+
+					this->m_monitor
+						->InvokeCurrentSceneItemDefaultContextMenu(
+							scene_item);
+				};
+
+				QMenu menu; //(m_mainWindow);
+
+				handled = DeserializeMenu(value, menu,
+							  defaultAction,
+							  defaultContextMenu);
+
+				if (handled) {
+					QContextMenuEvent *event = dynamic_cast<
+						QContextMenuEvent *>(e);
+
+					if (event)
+						menu.exec(event->globalPos());
+					else
+						handled = false;
+				}
+			}
+
+			if (scene_item)
+				obs_sceneitem_release(scene_item);
+
+			return handled;
+		}
+
+		return false;
+	}
+};
+
+/* ================================================================= */
+/* ================================================================= */
+/* ================================================================= */
+
+StreamElementsSceneItemsMonitor::StreamElementsSceneItemsMonitor(
+	QMainWindow *mainWindow)
+	: m_mainWindow(mainWindow)
+{
+	m_eventFilter = new SceneItemsLocalEventFilter(m_mainWindow, this);
+
+	QDockWidget *sceneItemsDock =
+		(QDockWidget *)m_mainWindow->findChild<QDockWidget *>(
+			"sourcesDock");
+
+	QDockWidget *scenesDock =
+		(QDockWidget *)m_mainWindow->findChild<QDockWidget *>(
+			"scenesDock");
+
+	if (!sceneItemsDock || !scenesDock)
+		return;
+
+	m_sceneItemsListView =
+		(QListView *)sceneItemsDock->findChild<QListView *>("sources");
+
+	if (!m_sceneItemsListView)
+		return;
+
+	QApplication::instance()->installEventFilter(m_eventFilter);
+	//m_sceneItemsListView->viewport()->installEventFilter(m_eventFilter);
+	//m_sceneItemsListView->installEventFilter(m_eventFilter);
+
+	m_sceneItemsModel = m_sceneItemsListView->model();
+
+	if (!m_sceneItemsModel)
+		return;
+
+	m_sceneItemsToolBar = (QToolBar *)sceneItemsDock->findChild<QToolBar *>(
+		"sourcesToolbar");
+
+	if (!m_sceneItemsToolBar)
+		return;
+
+	/* Subscribe to signals */
+
+	QObject::connect(
+		m_sceneItemsModel, &QAbstractItemModel::modelReset, this,
+		&StreamElementsSceneItemsMonitor::HandleSceneItemsModelReset);
+
+	QObject::connect(m_sceneItemsModel, &QAbstractItemModel::rowsInserted,
+			 this,
+			 &StreamElementsSceneItemsMonitor::
+				 HandleSceneItemsModelItemInsertedRemoved);
+
+	QObject::connect(m_sceneItemsModel, &QAbstractItemModel::rowsRemoved,
+			 this,
+			 &StreamElementsSceneItemsMonitor::
+				 HandleSceneItemsModelItemInsertedRemoved);
+
+	QObject::connect(
+		m_sceneItemsModel, &QAbstractItemModel::rowsMoved, this,
+		&StreamElementsSceneItemsMonitor::HandleSceneItemsModelItemMoved);
+
+	/* ======= */
+
+	ScheduleUpdateSceneItemsWidgets();
+
+	m_sceneItemsToolBarActions->SetNull();
+
+	UpdateSceneItemsToolbar();
+
+	m_enableSignals = true;
+}
+
+StreamElementsSceneItemsMonitor::~StreamElementsSceneItemsMonitor()
+{
+	if (!m_sceneItemsListView)
+		return;
+
+	QApplication::instance()->removeEventFilter(m_eventFilter);
+	//m_sceneItemsListView->viewport()->removeEventFilter(m_eventFilter);
+	//m_sceneItemsListView->removeEventFilter(m_eventFilter);
+
+	m_eventFilter->deleteLater();
+
+	DisconnectSignalHandlers();
+}
+
+void StreamElementsSceneItemsMonitor::OnObsExit()
+{
+	m_enableSignals = false;
+
+	m_updateSceneItemsWidgetsThrottledExecutive.Cancel();
+}
+
+void StreamElementsSceneItemsMonitor::DisconnectSignalHandlers()
+{
+	m_updateSceneItemsWidgetsThrottledExecutive.Cancel();
+
+	if (!m_sceneItemsModel)
+		return;
+
+	/* Unsubscribe from signals */
+
+	QObject::disconnect(
+		m_sceneItemsModel, &QAbstractItemModel::modelReset, this,
+		&StreamElementsSceneItemsMonitor::HandleSceneItemsModelReset);
+
+	QObject::disconnect(m_sceneItemsModel,
+			    &QAbstractItemModel::rowsInserted, this,
+			    &StreamElementsSceneItemsMonitor::
+				    HandleSceneItemsModelItemInsertedRemoved);
+
+	QObject::disconnect(m_sceneItemsModel, &QAbstractItemModel::rowsRemoved,
+			    this,
+			    &StreamElementsSceneItemsMonitor::
+				    HandleSceneItemsModelItemInsertedRemoved);
+
+	QObject::disconnect(
+		m_sceneItemsModel, &QAbstractItemModel::rowsMoved, this,
+		&StreamElementsSceneItemsMonitor::HandleSceneItemsModelItemMoved);
+}
+
+void StreamElementsSceneItemsMonitor::HandleSceneItemsModelReset()
+{
+	if (!m_enableSignals)
+		return;
+
+	ScheduleUpdateSceneItemsWidgets();
+}
+
+void StreamElementsSceneItemsMonitor::HandleSceneItemsModelItemInsertedRemoved(
+	const QModelIndex &, int, int)
+{
+	if (!m_enableSignals)
+		return;
+
+	ScheduleUpdateSceneItemsWidgets();
+}
+
+void StreamElementsSceneItemsMonitor::HandleSceneItemsModelItemMoved(
+	const QModelIndex &, int, int, const QModelIndex &, int)
+{
+	if (!m_enableSignals)
+		return;
+
+	ScheduleUpdateSceneItemsWidgets();
+}
+
+void StreamElementsSceneItemsMonitor::ScheduleUpdateSceneItemsWidgets()
+{
+	QtPostTask([=]() {
+		m_updateSceneItemsWidgetsThrottledExecutive.Signal(
+			[this]() { UpdateSceneItemsWidgets(); }, 250);
+	});
+}
+
+typedef std::vector<obs_sceneitem_t *> sceneitems_vector_t;
+
+static bool retrieveSceneItemsWithAddRef(obs_scene_t *, obs_sceneitem_t *item,
+					 void *ptr)
+{
+	sceneitems_vector_t *items =
+		reinterpret_cast<sceneitems_vector_t *>(ptr);
+
+	if (obs_sceneitem_is_group(item)) {
+		obs_data_t *data = obs_sceneitem_get_private_settings(item);
+
+		/* WARNING: COMPATIBILITY: COMPAT: This relies on OBS internal data management.
+		 *                                 May jeopardize compatibility with future releases
+		 *                                 of OBS.
+		 */
+		bool collapse = obs_data_get_bool(data, "collapsed");
+		if (!collapse) {
+			obs_scene_t *scene =
+				obs_sceneitem_group_get_scene(item);
+
+			obs_scene_enum_items(
+				scene, retrieveSceneItemsWithAddRef, items);
+		}
+
+		obs_data_release(data);
+	}
+
+	obs_sceneitem_addref(item);
+	items->insert(items->begin(), item);
+	return true;
+};
+
+static void release_sceneitems(sceneitems_vector_t *items)
+{
+	for (obs_sceneitem_t *item : *items) {
+		obs_sceneitem_release(item);
+	}
+}
+
+CefRefPtr<CefValue> StreamElementsSceneItemsMonitor::GetSceneItemPropertyValue(
+	obs_sceneitem_t *scene_item, const char *key)
+{
+	CefRefPtr<CefValue> result = CefValue::Create();
+	result->SetNull();
+
+	obs_data_t *scene_item_private_data =
+		obs_sceneitem_get_private_settings(scene_item);
+
+	const char *json = obs_data_get_string(scene_item_private_data, key);
+
+	if (json) {
+		result = CefParseJSON(json, JSON_PARSER_ALLOW_TRAILING_COMMAS);
+	}
+
+	obs_data_release(scene_item_private_data);
+
+	if (!result.get()) {
+		result = CefValue::Create();
+
+		result->SetNull();
+	}
+
+	return result;
+}
+
+void StreamElementsSceneItemsMonitor::SetSceneItemPropertyValue(
+	obs_sceneitem_t *scene_item, const char *key, CefRefPtr<CefValue> value,
+	bool triggerUpdate)
+{
+	obs_data_t *scene_item_private_data =
+		obs_sceneitem_get_private_settings(scene_item);
+
+	std::string json = CefWriteJSON(value, JSON_WRITER_DEFAULT).ToString();
+
+	obs_data_set_string(scene_item_private_data, key, json.c_str());
+
+	obs_data_release(scene_item_private_data);
+
+	if (triggerUpdate) {
+		ScheduleUpdateSceneItemsWidgets();
+	}
+}
+
+CefRefPtr<CefValue>
+StreamElementsSceneItemsMonitor::GetSceneItemIcon(obs_sceneitem_t *scene_item)
+{
+	CefRefPtr<CefValue> iconValue = GetSceneItemPropertyValue(
+		scene_item, ITEM_PRIVATE_DATA_KEY_UI_ICON);
+
+	if (iconValue->GetType() != VTYPE_DICTIONARY) {
+		iconValue->SetNull();
+	}
+
+	return iconValue;
+}
+
+void StreamElementsSceneItemsMonitor::SetSceneItemIcon(
+	obs_sceneitem_t *scene_item, CefRefPtr<CefValue> m_icon)
+{
+	SetSceneItemPropertyValue(scene_item, ITEM_PRIVATE_DATA_KEY_UI_ICON,
+				  m_icon);
+}
+
+CefRefPtr<CefListValue> StreamElementsSceneItemsMonitor::GetSceneItemActions(
+	obs_sceneitem_t *scene_item)
+{
+	CefRefPtr<CefValue> actionsValue = GetSceneItemPropertyValue(
+		scene_item, ITEM_PRIVATE_DATA_KEY_UI_AUXILIARY_ACTIONS);
+
+	if (actionsValue->GetType() != VTYPE_LIST) {
+		actionsValue->SetList(CefListValue::Create());
+	}
+
+	return actionsValue->GetList();
+}
+
+void StreamElementsSceneItemsMonitor::SetSceneItemActions(
+	obs_sceneitem_t *scene_item, CefRefPtr<CefListValue> m_actions)
+{
+	CefRefPtr<CefValue> val = CefValue::Create();
+
+	val->SetList(m_actions);
+
+	SetSceneItemPropertyValue(
+		scene_item, ITEM_PRIVATE_DATA_KEY_UI_AUXILIARY_ACTIONS, val);
+}
+
+CefRefPtr<CefValue> StreamElementsSceneItemsMonitor::GetSceneItemDefaultAction(
+	obs_sceneitem_t *scene_item)
+{
+	return GetSceneItemPropertyValue(
+		scene_item, ITEM_PRIVATE_DATA_KEY_UI_DEFAULT_ACTION);
+}
+
+void StreamElementsSceneItemsMonitor::SetSceneItemDefaultAction(
+	obs_sceneitem_t *scene_item, CefRefPtr<CefValue> action)
+{
+	SetSceneItemPropertyValue(
+		scene_item, ITEM_PRIVATE_DATA_KEY_UI_DEFAULT_ACTION, action);
+}
+
+CefRefPtr<CefValue> StreamElementsSceneItemsMonitor::GetSceneItemContextMenu(
+	obs_sceneitem_t *scene_item)
+{
+	return GetSceneItemPropertyValue(scene_item,
+					 ITEM_PRIVATE_DATA_KEY_UI_CONTEXT_MENU);
+}
+
+void StreamElementsSceneItemsMonitor::SetSceneItemContextMenu(
+	obs_sceneitem_t *scene_item, CefRefPtr<CefValue> menu)
+{
+	SetSceneItemPropertyValue(scene_item,
+				  ITEM_PRIVATE_DATA_KEY_UI_CONTEXT_MENU, menu);
+}
+
+CefRefPtr<CefValue> StreamElementsSceneItemsMonitor::GetSceneItemAuxiliaryData(
+	obs_sceneitem_t *scene_item)
+{
+	return GetSceneItemPropertyValue(scene_item,
+					 ITEM_PRIVATE_DATA_KEY_APPDATA);
+}
+
+void StreamElementsSceneItemsMonitor::SetSceneItemAuxiliaryData(
+	obs_sceneitem_t *scene_item, CefRefPtr<CefValue> data)
+{
+	SetSceneItemPropertyValue(scene_item, ITEM_PRIVATE_DATA_KEY_APPDATA,
+				  data, false);
+}
+
+static void
+deserializeAuxSceneItemsControls(StreamElementsSceneItemsMonitor *monitor,
+				 obs_sceneitem_t *scene_item,
+				 QWidget *auxWidget, QWidget *parentWidget)
+{
+	auxWidget->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
+
+	QHBoxLayout *auxLayout =
+		static_cast<QHBoxLayout *>(auxWidget->layout());
+
+	if (!auxLayout) {
+		auxLayout = new QHBoxLayout();
+		auxLayout->setContentsMargins(0, 0, 0, 0);
+		auxWidget->setLayout(auxLayout);
+	}
+
+	while (auxLayout->count()) {
+		auxLayout->removeItem(auxLayout->itemAt(0));
+	}
+
+	CefRefPtr<CefListValue> list = monitor->GetSceneItemActions(scene_item);
+
+	for (size_t index = 0; index < list->GetSize(); ++index) {
+		QWidget *control = DeserializeAuxiliaryControlWidget(
+			list->GetValue(index),
+			[monitor, scene_item]() {
+				monitor->InvokeCurrentSceneItemDefaultAction(
+					scene_item);
+			},
+			[monitor, scene_item]() {
+				monitor->InvokeCurrentSceneItemDefaultContextMenu(
+					scene_item);
+			});
+
+		if (!control)
+			continue;
+
+		auxLayout->addWidget(control);
+		auxLayout->addSpacing(2);
+	}
+}
+
+static void deserializeSceneItemIcon(StreamElementsSceneItemsMonitor *monitor,
+				     obs_scene_t *scene,
+				     obs_sceneitem_t *scene_item,
+				     QWidget *iconWidget, QWidget *parentWidget,
+				     QPixmap *defaultPixmap)
+{
+	iconWidget->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
+
+	QHBoxLayout *iconLayout =
+		static_cast<QHBoxLayout *>(iconWidget->layout());
+
+	if (!iconLayout) {
+		iconLayout = new QHBoxLayout();
+		iconLayout->setContentsMargins(0, 0, 0, 0);
+		iconWidget->setLayout(iconLayout);
+	}
+
+	while (iconLayout->count()) {
+		iconLayout->removeItem(iconLayout->itemAt(0));
+	}
+
+	std::string url = "";
+
+	QWidget *itemIcon = DeserializeRemoteIconWidget(
+		monitor->GetSceneItemIcon(scene_item), defaultPixmap);
+
+	iconLayout->addWidget(itemIcon);
+	iconLayout->addSpacing(2);
+}
+
+void StreamElementsSceneItemsMonitor::UpdateSceneItemsWidgets()
+{
+	QtPostTask([=]() {
+		sceneitems_vector_t sceneItems;
+
+		obs_source_t *sceneSource = obs_frontend_get_current_scene();
+		obs_scene_t *scene = obs_scene_from_source(
+			sceneSource); // does not increment refcount
+
+		obs_scene_enum_items(scene, retrieveSceneItemsWithAddRef,
+				     &sceneItems);
+
+		for (int rowIndex = 0;
+		     rowIndex < m_sceneItemsModel->rowCount() &&
+		     rowIndex < sceneItems.size();
+		     ++rowIndex) {
+			obs_sceneitem_t *scene_item = sceneItems[rowIndex];
+
+			QModelIndex index =
+				m_sceneItemsModel->index(rowIndex, 0);
+			QWidget *widget =
+				m_sceneItemsListView->indexWidget(index);
+
+			if (!widget)
+				continue;
+
+			QBoxLayout *layout =
+				dynamic_cast<QBoxLayout *>(widget->layout());
+
+			if (!layout)
+				continue;
+
+			bool isSignedIn = !StreamElementsConfig::GetInstance()
+						   ->IsOnBoardingMode();
+
+			{
+				QList<QWidget *> list =
+					widget->findChildren<QWidget *>(
+						"streamelements_aux_widget",
+						Qt::FindChildrenRecursively);
+
+				for (QWidget *w : list) {
+					w->setVisible(false);
+					layout->removeWidget(w);
+				}
+			}
+
+			{
+				QList<QWidget *> list =
+					widget->findChildren<QWidget *>(
+						"streamelements_icon_widget",
+						Qt::FindChildrenRecursively);
+
+				for (QWidget *w : list) {
+					w->setVisible(false);
+					layout->removeWidget(w);
+				}
+			}
+
+			QPixmap defaultIconPixmap(16, 16);
+			defaultIconPixmap.fill(Qt::transparent);
+
+			QLabel *nativeIconLabel = nullptr;
+			QLabel *nativeTextLabel = nullptr;
+
+			{
+				QList<QLabel *> list =
+					widget->findChildren<QLabel *>(
+						QString(),
+						Qt::FindDirectChildrenOnly);
+
+				for (QLabel *label : list) {
+					if (label->pixmap()) {
+						// Native icon
+						label->setVisible(!isSignedIn);
+
+						if (!nativeIconLabel) {
+							nativeIconLabel = label;
+						}
+
+						if (isSignedIn) {
+							defaultIconPixmap =
+								*label->pixmap();
+						}
+					} else {
+						nativeTextLabel = label;
+					}
+				}
+			}
+
+			if (isSignedIn) {
+				/* Create and add icon widget to the item's layout */
+
+				QWidget *iconWidget = new QWidget();
+				iconWidget->setObjectName(
+					"streamelements_icon_widget");
+
+				// TODO: TBD: When OBS 25 is released, only leave the first IF
+				if (nativeIconLabel)
+					layout->insertWidget(
+						layout->indexOf(
+							nativeIconLabel),
+						iconWidget);
+				else
+					layout->insertWidget(
+						layout->indexOf(
+							nativeTextLabel),
+						iconWidget);
+
+				/* Create and add auxiliary actions widget to the item's layout */
+
+				QWidget *auxWidget = new QWidget();
+				auxWidget->setObjectName(
+					"streamelements_aux_widget");
+
+				int auxWidgetPos =
+					nativeTextLabel
+						? layout->indexOf(
+							  nativeTextLabel) +
+							  1
+						: widget->children().count() >=
+								  6
+							  ? layout->count() -
+								    3 // OBS 25+ has an icon
+							  : layout->count() -
+								    2; // OBS 24- has no icon
+
+#ifndef __APPLE__
+				layout->insertWidget(auxWidgetPos, auxWidget);
+#else
+				layout->insertWidget(auxWidgetPos - 1,
+						     auxWidget);
+#endif
+
+				deserializeSceneItemIcon(this, scene,
+							 scene_item, iconWidget,
+							 widget,
+							 &defaultIconPixmap);
+
+				deserializeAuxSceneItemsControls(
+					this, scene_item, auxWidget, widget);
+
+				{
+					QVariant value(QString(
+						GetIdFromPointer(scene_item)
+							.c_str()));
+
+					widget->setProperty(
+						WIDGET_PROP_SCENE_ITEM_ID,
+						value);
+				}
+			}
+		}
+
+		release_sceneitems(&sceneItems);
+		obs_source_release(sceneSource);
+	});
+}
+
+bool StreamElementsSceneItemsMonitor::InvokeCurrentSceneItemDefaultAction(
+	obs_sceneitem_t *scene_item)
+{
+	bool result = false;
+
+	sceneitems_vector_t sceneItems;
+
+	obs_source_t *sceneSource = obs_frontend_get_current_scene();
+	obs_scene_t *scene = obs_scene_from_source(
+		sceneSource); // does not increment refcount
+
+	obs_scene_enum_items(scene, retrieveSceneItemsWithAddRef, &sceneItems);
+
+	for (int rowIndex = 0; rowIndex < m_sceneItemsModel->rowCount() &&
+			       rowIndex < sceneItems.size() && !result;
+	     ++rowIndex) {
+		obs_sceneitem_t *item = sceneItems[rowIndex];
+
+		if (scene_item != item)
+			continue;
+
+		QModelIndex index = m_sceneItemsModel->index(rowIndex, 0);
+		QWidget *widget = m_sceneItemsListView->indexWidget(index);
+
+		if (!widget)
+			continue;
+
+		QVariant value = widget->property(
+			WIDGET_PROP_DEFAULT_ACTION_BYPASS_COUNT);
+		if (!value.isValid()) {
+			value.setValue<int>(1);
+		} else {
+			value.setValue<int>(value.value<int>() + 1);
+		}
+
+		widget->setProperty(WIDGET_PROP_DEFAULT_ACTION_BYPASS_COUNT,
+				    value);
+
+		QApplication::sendEvent(
+			widget,
+			new QMouseEvent(QMouseEvent::MouseButtonDblClick,
+					QPoint(0, 0), Qt::LeftButton,
+					Qt::NoButton, Qt::NoModifier));
+
+		result = true;
+	}
+
+	release_sceneitems(&sceneItems);
+	obs_source_release(sceneSource);
+
+	return result;
+}
+
+bool StreamElementsSceneItemsMonitor::InvokeCurrentSceneItemDefaultContextMenu(
+	obs_sceneitem_t *scene_item)
+{
+	bool result = false;
+
+	sceneitems_vector_t sceneItems;
+
+	obs_source_t *sceneSource = obs_frontend_get_current_scene();
+	obs_scene_t *scene = obs_scene_from_source(
+		sceneSource); // does not increment refcount
+
+	obs_scene_enum_items(scene, retrieveSceneItemsWithAddRef, &sceneItems);
+
+	for (int rowIndex = 0; rowIndex < m_sceneItemsModel->rowCount() &&
+			       rowIndex < sceneItems.size() && !result;
+	     ++rowIndex) {
+		obs_sceneitem_t *item = sceneItems[rowIndex];
+
+		if (scene_item != item)
+			continue;
+
+		QModelIndex index = m_sceneItemsModel->index(rowIndex, 0);
+		QWidget *widget = m_sceneItemsListView->indexWidget(index);
+
+		if (!widget)
+			continue;
+
+		m_sceneItemsListView->scrollTo(index);
+		m_sceneItemsListView->setCurrentIndex(index);
+
+		const QRect rect = m_sceneItemsListView->visualRect(index);
+
+		QtPostTask([=]() {
+			m_sceneItemsListView->customContextMenuRequested(
+				QPoint(rect.left() + (rect.width() / 2),
+				       rect.top() + (rect.height() / 2)));
+		});
+
+		result = true;
+	}
+
+	release_sceneitems(&sceneItems);
+	obs_source_release(sceneSource);
+
+	return result;
+}
+
+void StreamElementsSceneItemsMonitor::UpdateSceneItemsToolbar()
+{
+	QtPostTask([=]() {
+		QWidget *widget = m_sceneItemsToolBar->findChild<QWidget *>(
+			"streamelements_sources_toolbar_aux_actions");
+
+		if (widget)
+			m_sceneItemsToolBar->layout()->removeWidget(widget);
+
+		widget = new QWidget();
+		widget->setObjectName(
+			"streamelements_sources_toolbar_aux_actions");
+
+		QHBoxLayout *layout = new QHBoxLayout();
+		layout->setContentsMargins(0, 0, 0, 0);
+		widget->setLayout(layout);
+
+		layout->addSpacerItem(new QSpacerItem(
+			16, 16, QSizePolicy::Expanding, QSizePolicy::Minimum));
+
+		if (!m_sceneItemsToolBarActions.get() ||
+		    m_sceneItemsToolBarActions->GetType() != VTYPE_LIST)
+			return;
+
+		CefRefPtr<CefListValue> list =
+			m_sceneItemsToolBarActions->GetList();
+
+		for (size_t index = 0; index < list->GetSize(); ++index) {
+			QWidget *control = DeserializeAuxiliaryControlWidget(
+				list->GetValue(index));
+
+			if (!control)
+				continue;
+
+			layout->addWidget(control);
+			layout->addSpacing(1);
+		}
+
+		widget->setStyleSheet("background: none");
+
+		widget->setSizePolicy(QSizePolicy::Expanding,
+				      QSizePolicy::Minimum);
+
+		m_sceneItemsToolBar->addWidget(widget);
+	});
+}

--- a/streamelements/StreamElementsSceneItemsMonitor.hpp
+++ b/streamelements/StreamElementsSceneItemsMonitor.hpp
@@ -1,0 +1,129 @@
+#pragma once
+
+#include "StreamElementsObsAppMonitor.hpp"
+#include "StreamElementsDeferredExecutive.hpp"
+#include "StreamElementsUtils.hpp"
+
+#include <QObject>
+#include <QMainWindow>
+#include <QListView>
+#include <QAbstractItemModel>
+#include <QToolBar>
+#include <QListWidget>
+
+#include <obs.h>
+
+#include "cef-headers.hpp"
+
+class StreamElementsSceneItemsMonitor : public QObject,
+					public StreamElementsObsAppMonitor {
+public:
+	StreamElementsSceneItemsMonitor(QMainWindow *mainWindow);
+	virtual ~StreamElementsSceneItemsMonitor();
+
+	/* ==================================================== */
+
+	static CefRefPtr<CefValue>
+	GetSceneItemPropertyValue(obs_sceneitem_t *scene_item, const char *key);
+
+	void SetSceneItemPropertyValue(obs_sceneitem_t *scene_item,
+				       const char *key,
+				       CefRefPtr<CefValue> value,
+				       bool triggerUpdate = true);
+
+	static CefRefPtr<CefListValue>
+	GetSceneItemActions(obs_sceneitem_t *scene_item);
+
+	void SetSceneItemActions(obs_sceneitem_t *scene_item,
+				 CefRefPtr<CefListValue> m_actions);
+
+	static CefRefPtr<CefValue>
+	GetSceneItemIcon(obs_sceneitem_t *scene_item);
+
+	void SetSceneItemIcon(obs_sceneitem_t *scene_item,
+			      CefRefPtr<CefValue> m_icon);
+
+	static CefRefPtr<CefValue>
+	GetSceneItemDefaultAction(obs_sceneitem_t *scene_item);
+
+	void SetSceneItemDefaultAction(obs_sceneitem_t *scene_item,
+				       CefRefPtr<CefValue> action);
+
+	static CefRefPtr<CefValue>
+	GetSceneItemContextMenu(obs_sceneitem_t *scene_item);
+
+	void SetSceneItemContextMenu(obs_sceneitem_t *scene_item,
+				     CefRefPtr<CefValue> menu);
+
+	CefRefPtr<CefValue> static GetSceneItemAuxiliaryData(
+		obs_sceneitem_t *scene_item);
+
+	void SetSceneItemAuxiliaryData(obs_sceneitem_t *scene_item,
+				       CefRefPtr<CefValue> data);
+
+	bool InvokeCurrentSceneItemDefaultAction(obs_sceneitem_t *scene_item);
+
+	bool
+	InvokeCurrentSceneItemDefaultContextMenu(obs_sceneitem_t *scene_item);
+
+	bool
+	DeserializeSceneItemsAuxiliaryActions(CefRefPtr<CefValue> m_actions)
+	{
+		m_sceneItemsToolBarActions = m_actions->Copy();
+
+		UpdateSceneItemsToolbar();
+
+		return true;
+	}
+
+	void SerializeSceneItemsAuxiliaryActions(CefRefPtr<CefValue> &output)
+	{
+		output = m_sceneItemsToolBarActions->Copy();
+	}
+
+	void Update() { ScheduleUpdateSceneItemsWidgets(); }
+
+	QWidget* GetWidgetAtLocalPosition(const QPointF &p) {
+		QModelIndex index = m_sceneItemsListView->indexAt(QPoint(p.x(), p.y()));
+
+		if (!index.isValid())
+			return nullptr;
+
+		return m_sceneItemsListView->indexWidget(index);
+	}
+
+	QListView* GetSceneItemsListView() { return m_sceneItemsListView; }
+
+private:
+	void DisconnectSignalHandlers();
+
+	void ScheduleUpdateSceneItemsWidgets();
+
+	void UpdateSceneItemsWidgets();
+
+	void UpdateSceneItemsToolbar();
+
+private slots:
+	void HandleSceneItemsModelReset();
+	void HandleSceneItemsModelItemInsertedRemoved(const QModelIndex &, int,
+						      int);
+	void HandleSceneItemsModelItemMoved(const QModelIndex &, int, int,
+					    const QModelIndex &, int);
+
+protected:
+	virtual void OnObsExit() override;
+
+private:
+	QMainWindow *m_mainWindow;
+	QListView *m_sceneItemsListView = nullptr;
+	//QListView *m_scenesListView = nullptr;
+	//QListWidget *m_scenesListWidget = nullptr;
+	QToolBar *m_sceneItemsToolBar = nullptr;
+	QAbstractItemModel *m_sceneItemsModel = nullptr;
+	//QAbstractItemModel *m_scenesModel = nullptr;
+	bool m_enableSignals = false;
+	StreamElementsDeferredExecutive
+		m_updateSceneItemsWidgetsThrottledExecutive;
+	QObject *m_eventFilter = nullptr;
+	CefRefPtr<CefValue> m_sceneItemsToolBarActions = CefValue::Create();
+};

--- a/streamelements/StreamElementsScenesListWidgetManager.cpp
+++ b/streamelements/StreamElementsScenesListWidgetManager.cpp
@@ -1,0 +1,756 @@
+#include "StreamElementsScenesListWidgetManager.hpp"
+#include "StreamElementsUtils.hpp"
+#include "StreamElementsRemoteIconLoader.hpp"
+#include "StreamElementsConfig.hpp"
+
+#include <obs.h>
+#include <obs-frontend-api.h>
+
+#include <QDockWidget>
+#include <QLayout>
+#include <QSizePolicy>
+#include <QLabel>
+#include <QPushButton>
+#include <QAbstractListModel>
+#include <QMouseEvent>
+
+static const char *ITEM_PRIVATE_DATA_KEY_UI_ICON = "streamelements_ui_icon";
+
+static const char *ITEM_PRIVATE_DATA_KEY_APPDATA = "streamelements_app_data";
+
+static const char *WIDGET_PROP_SCENE_ID = "streamelements_scene_id";
+
+static const char *WIDGET_PROP_DEFAULT_ACTION_BYPASS_COUNT =
+	"streamelements_default_action_bypass_count";
+
+static const char *ITEM_PRIVATE_DATA_KEY_UI_DEFAULT_ACTION =
+	"streamelements_ui_default_action";
+
+static const char *ITEM_PRIVATE_DATA_KEY_UI_CONTEXT_MENU =
+	"streamelements_ui_context_menu";
+
+/* ================================================================= */
+/* ================================================================= */
+/* ================================================================= */
+
+class ItemData : public QObject {
+private:
+	QIcon m_icon;
+	CefRefPtr<CefValue> m_defaultAction;
+	CefRefPtr<CefValue> m_contextMenu;
+	CefRefPtr<StreamElementsRemoteIconLoader> m_iconLoader = nullptr;
+	std::function<void()> m_updateListener;
+
+	void ClearIcon()
+	{
+		QPixmap pm(16, 16);
+		pm.fill(Qt::transparent);
+		m_icon = QIcon(pm);
+	}
+
+public:
+	ItemData(std::function<void()> updateListener)
+		: m_updateListener(updateListener),
+		  m_defaultAction(CefValue::Create()),
+		  m_contextMenu(CefValue::Create())
+	{
+		ClearIcon();
+	}
+
+	~ItemData()
+	{
+		if (m_iconLoader)
+			m_iconLoader->Cancel();
+	}
+
+	QIcon icon() { return m_icon; }
+	CefRefPtr<CefValue> defaultAction() { return m_defaultAction; }
+	CefRefPtr<CefValue> contextMenu() { return m_contextMenu; }
+
+	void LoadIconUrl(std::string url)
+	{
+		if (m_iconLoader)
+			m_iconLoader->Cancel();
+
+		m_iconLoader = StreamElementsRemoteIconLoader::Create(
+			[this](const QIcon &newIcon) {
+				m_icon = QIcon(newIcon);
+
+				m_updateListener();
+			},
+			nullptr);
+
+		m_iconLoader->LoadUrl(url.c_str());
+	}
+
+	void DeserializeDefaultAction(CefRefPtr<CefValue> input)
+	{
+		m_defaultAction = input->Copy();
+	}
+
+	void DeserializeContextMenu(CefRefPtr<CefValue> input)
+	{
+		m_contextMenu = input->Copy();
+	}
+
+	void DeserializeIcon(CefRefPtr<CefValue> input)
+	{
+		ClearIcon();
+
+		QtPostTask([this]() { m_updateListener(); });
+
+		if (!input.get() || input->GetType() != VTYPE_DICTIONARY)
+			return;
+
+		CefRefPtr<CefDictionaryValue> d = input->GetDictionary();
+
+		if (!d->HasKey("url") || d->GetType("url") != VTYPE_STRING)
+			return;
+
+		LoadIconUrl(d->GetString("url").ToString());
+	}
+};
+
+class SourceDataManager : public QObject {
+private:
+	std::map<obs_source_t *, ItemData *> m_itemData;
+
+protected:
+	SourceDataManager() {}
+
+public:
+	void clear()
+	{
+		for (auto kv : m_itemData) {
+			kv.second->deleteLater();
+		}
+
+		m_itemData.clear();
+	}
+
+	void removeData(obs_source_t *key)
+	{
+		if (!m_itemData.count(key))
+			return;
+
+		m_itemData[key]->deleteLater();
+		m_itemData.erase(key);
+	}
+
+	void setData(obs_source_t *key, ItemData *value)
+	{
+		removeData(key);
+
+		m_itemData[key] = value;
+	}
+
+	ItemData *data(obs_source_t *key) const
+	{
+		for (auto kv : m_itemData) {
+			if (kv.first == key)
+				return kv.second;
+		}
+
+		return nullptr;
+	}
+
+	static SourceDataManager *instance() { return &s_instance; }
+
+private:
+	static SourceDataManager s_instance;
+};
+
+SourceDataManager SourceDataManager::s_instance;
+
+/* ================================================================= */
+/* ================================================================= */
+/* ================================================================= */
+
+static class ScenesLocalEventFilter : public QObject {
+private:
+	StreamElementsScenesListWidgetManager *m_manager;
+
+public:
+	ScenesLocalEventFilter(StreamElementsScenesListWidgetManager *manager)
+		: m_manager(manager)
+	{
+	}
+
+	~ScenesLocalEventFilter() {}
+
+protected:
+	virtual bool eventFilter(QObject *o, QEvent *e) override
+	{
+		if (!o)
+			return false;
+
+		if (e->type() != QEvent::MouseButtonDblClick && e->type() != QEvent::ContextMenu)
+			return false;
+
+		if (!m_manager->GetScenesListWidget() ||
+		    !m_manager->GetScenesListWidget()->viewport() ||
+		    (o != m_manager->GetScenesListWidget()->viewport() &&
+		     o != m_manager->GetScenesListWidget()))
+			return false;
+
+		if (e->type() == QEvent::MouseButtonDblClick) {
+			QVariant bypassValue = o->property(
+				WIDGET_PROP_DEFAULT_ACTION_BYPASS_COUNT);
+			if (bypassValue.isValid()) {
+				if (bypassValue.value<int>() > 0) {
+					bypassValue.setValue<int>(
+						bypassValue.value<int>() - 1);
+
+					o->setProperty(
+						WIDGET_PROP_DEFAULT_ACTION_BYPASS_COUNT,
+						bypassValue);
+
+					return false;
+				}
+			}
+
+			obs_source_t *scene = obs_frontend_get_current_scene();
+
+			if (!scene)
+				return false;
+
+			bool handled = false;
+
+			CefRefPtr<CefValue> value =
+				m_manager->GetSceneDefaultAction(scene);
+
+			if (value->GetType() == VTYPE_DICTIONARY) {
+				auto defaultAction = [this, scene]() {
+					if (!scene)
+						return;
+
+					m_manager->InvokeCurrentSceneDefaultAction();
+				};
+
+				auto defaultContextMenu = [this, scene]() {
+					if (!scene)
+						return;
+
+					m_manager->InvokeCurrentSceneDefaultContextMenu();
+				};
+
+				handled = DeserializeAndInvokeAction(
+					value, defaultAction,
+					defaultContextMenu);
+
+				if (scene)
+					obs_source_release(scene);
+			}
+
+			return handled;
+		}
+
+		if (e->type() == QEvent::ContextMenu) {
+			obs_source_t *scene = obs_frontend_get_current_scene();
+
+			if (!scene)
+				return false;
+
+			CefRefPtr<CefValue> value =
+				m_manager->GetSceneContextMenu(scene);
+
+			bool handled = false;
+
+			if (value->GetType() == VTYPE_LIST &&
+			    value->GetList()->GetSize()) {
+				auto defaultAction = [this, scene]() {
+					if (!scene)
+						return;
+
+					m_manager
+						->InvokeCurrentSceneDefaultAction();
+				};
+
+				auto defaultContextMenu = [this, scene]() {
+					if (!scene)
+						return;
+
+					m_manager
+						->InvokeCurrentSceneDefaultContextMenu();
+				};
+
+				QMenu menu; //(m_mainWindow);
+
+				handled = DeserializeMenu(value, menu,
+							  defaultAction,
+							  defaultContextMenu);
+
+				if (handled) {
+					QContextMenuEvent *event = dynamic_cast<
+						QContextMenuEvent *>(e);
+
+					if (event)
+						menu.exec(event->globalPos());
+					else
+						handled = false;
+				}
+			}
+
+			if (scene)
+				obs_source_release(scene);
+
+			return handled;
+		}
+
+		return false;
+	}
+};
+
+/* ================================================================= */
+/* ================================================================= */
+/* ================================================================= */
+
+StreamElementsScenesListWidgetManager::StreamElementsScenesListWidgetManager(
+	QMainWindow *mainWindow)
+	: m_mainWindow(mainWindow)
+{
+	QDockWidget *scenesDock =
+		(QDockWidget *)m_mainWindow->findChild<QDockWidget *>(
+			"scenesDock");
+
+	if (!scenesDock)
+		return;
+
+	m_nativeWidget =
+		(QListWidget *)scenesDock->findChild<QListWidget *>("scenes");
+
+	if (!m_nativeWidget)
+		return;
+
+	m_eventFilter = new ScenesLocalEventFilter(this);
+
+	QApplication::instance()->installEventFilter(m_eventFilter);
+	//m_nativeWidget->viewport()->installEventFilter(m_eventFilter);
+	//m_nativeWidget->installEventFilter(m_eventFilter);
+
+	m_scenesToolBar =
+		(QToolBar *)scenesDock->findChild<QToolBar *>("scenesToolbar");
+
+	if (!m_scenesToolBar)
+		return;
+
+	m_scenesToolBarActions->SetNull();
+
+	QtPostTask([this]() {
+		auto model = m_nativeWidget->model();
+
+		/* Subscribe to signals */
+
+		QObject::connect(model, &QAbstractItemModel::modelReset, this,
+				 &StreamElementsScenesListWidgetManager::
+					 HandleScenesModelReset);
+
+		QObject::connect(model, &QAbstractItemModel::rowsInserted, this,
+				 &StreamElementsScenesListWidgetManager::
+					 HandleScenesModelItemInsertedRemoved);
+
+		QObject::connect(model, &QAbstractItemModel::rowsRemoved, this,
+				 &StreamElementsScenesListWidgetManager::
+					 HandleScenesModelItemInsertedRemoved);
+
+		QObject::connect(model, &QAbstractItemModel::rowsMoved, this,
+				 &StreamElementsScenesListWidgetManager::
+					 HandleScenesModelItemMoved);
+
+		signal_handler_connect(
+			obs_get_signal_handler(), "source_rename",
+			StreamElementsScenesListWidgetManager::HandleSceneRename,
+			this);
+
+		QObject::connect(m_nativeWidget,
+				 &QListWidget::itemDoubleClicked, this,
+				 &StreamElementsScenesListWidgetManager::
+					 HandleScenesItemDoubleClicked);
+
+		//m_nativeWidget->setVisible(false);
+		//m_nativeWidget->setDisabled(true);
+
+		m_nativeWidget->setEditTriggers(
+			QAbstractItemView::NoEditTriggers);
+
+		//m_editDelegate = new SceneListItemDelegate();
+		//m_prevEditDelegate = m_nativeWidget->itemDelegate();
+		//m_nativeWidget->setItemDelegate(m_editDelegate);
+
+		ScheduleUpdateWidgets();
+		UpdateScenesToolbar();
+
+		m_enableSignals = true;
+	});
+}
+
+StreamElementsScenesListWidgetManager::~StreamElementsScenesListWidgetManager()
+{
+	m_enableSignals = false;
+
+	if (!m_nativeWidget)
+		return;
+
+	//if (!m_nativeWidget->viewport())
+	//	return;
+
+	QApplication::instance()->removeEventFilter(m_eventFilter);
+	//m_nativeWidget->viewport()->removeEventFilter(m_eventFilter);
+	//m_nativeWidget->removeEventFilter(m_eventFilter);
+
+	m_eventFilter->deleteLater();
+
+	auto model = m_nativeWidget->model();
+
+	QObject::disconnect(m_nativeWidget, &QListWidget::itemDoubleClicked,
+			    this,
+			    &StreamElementsScenesListWidgetManager::
+				    HandleScenesItemDoubleClicked);
+
+	signal_handler_disconnect(
+		obs_get_signal_handler(), "source_rename",
+		StreamElementsScenesListWidgetManager::HandleSceneRename, this);
+
+	QObject::disconnect(
+		model, &QAbstractItemModel::modelReset, this,
+		&StreamElementsScenesListWidgetManager::HandleScenesModelReset);
+
+	QObject::disconnect(model, &QAbstractItemModel::rowsInserted, this,
+			    &StreamElementsScenesListWidgetManager::
+				    HandleScenesModelItemInsertedRemoved);
+
+	QObject::disconnect(model, &QAbstractItemModel::rowsRemoved, this,
+			    &StreamElementsScenesListWidgetManager::
+				    HandleScenesModelItemInsertedRemoved);
+
+	QObject::disconnect(model, &QAbstractItemModel::rowsMoved, this,
+			    &StreamElementsScenesListWidgetManager::
+				    HandleScenesModelItemMoved);
+
+	//m_nativeWidget->setItemDelegate(m_prevEditDelegate);
+	//m_editDelegate->deleteLater();
+}
+
+void StreamElementsScenesListWidgetManager::HandleSceneRename(
+	void *data, calldata_t *params)
+{
+	StreamElementsScenesListWidgetManager *self =
+		(StreamElementsScenesListWidgetManager *)data;
+
+	self->ScheduleUpdateWidgets();
+}
+
+void StreamElementsScenesListWidgetManager::HandleScenesModelReset()
+{
+	if (!m_enableSignals)
+		return;
+
+	ScheduleUpdateWidgets();
+}
+
+void StreamElementsScenesListWidgetManager::HandleScenesModelItemInsertedRemoved(
+	const QModelIndex &, int, int)
+{
+	if (!m_enableSignals)
+		return;
+
+	ScheduleUpdateWidgets();
+}
+
+void StreamElementsScenesListWidgetManager::HandleScenesModelItemMoved(
+	const QModelIndex &, int, int, const QModelIndex &, int)
+{
+	if (!m_enableSignals)
+		return;
+
+	ScheduleUpdateWidgets();
+}
+
+CefRefPtr<CefValue>
+StreamElementsScenesListWidgetManager::GetScenePropertyValue(
+	obs_source_t *scene, const char *key)
+{
+	CefRefPtr<CefValue> result = CefValue::Create();
+	result->SetNull();
+
+	obs_data_t *private_data = obs_source_get_private_settings(scene);
+
+	const char *json = obs_data_get_string(private_data, key);
+
+	if (json) {
+		result = CefParseJSON(json, JSON_PARSER_ALLOW_TRAILING_COMMAS);
+	}
+
+	obs_data_release(private_data);
+
+	if (!result.get()) {
+		result = CefValue::Create();
+
+		result->SetNull();
+	}
+
+	return result;
+}
+
+void StreamElementsScenesListWidgetManager::SetScenePropertyValue(
+	obs_source_t *scene, const char *key, CefRefPtr<CefValue> value,
+	bool triggerUpdate)
+{
+	obs_data_t *private_data = obs_source_get_private_settings(scene);
+
+	std::string json = CefWriteJSON(value, JSON_WRITER_DEFAULT).ToString();
+
+	obs_data_set_string(private_data, key, json.c_str());
+
+	obs_data_release(private_data);
+
+	if (triggerUpdate) {
+		ScheduleUpdateWidgets();
+	}
+}
+
+CefRefPtr<CefValue>
+StreamElementsScenesListWidgetManager::GetSceneAuxiliaryData(obs_source_t *scene)
+{
+	return GetScenePropertyValue(scene, ITEM_PRIVATE_DATA_KEY_APPDATA);
+}
+
+void StreamElementsScenesListWidgetManager::SetSceneAuxiliaryData(
+	obs_source_t *scene, CefRefPtr<CefValue> data)
+{
+	SetScenePropertyValue(scene, ITEM_PRIVATE_DATA_KEY_APPDATA, data,
+			      false);
+}
+
+CefRefPtr<CefValue>
+StreamElementsScenesListWidgetManager::GetSceneIcon(obs_source_t *scene)
+{
+	CefRefPtr<CefValue> iconValue =
+		GetScenePropertyValue(scene, ITEM_PRIVATE_DATA_KEY_UI_ICON);
+
+	if (iconValue->GetType() != VTYPE_DICTIONARY) {
+		iconValue->SetNull();
+	}
+
+	return iconValue;
+}
+
+void StreamElementsScenesListWidgetManager::SetSceneIcon(
+	obs_source_t *scene, CefRefPtr<CefValue> icon)
+{
+	auto data = SourceDataManager::instance()->data(scene);
+	if (data) {
+		data->DeserializeIcon(icon);
+	}
+
+	SetScenePropertyValue(scene, ITEM_PRIVATE_DATA_KEY_UI_ICON, icon);
+}
+
+CefRefPtr<CefValue>
+StreamElementsScenesListWidgetManager::GetSceneDefaultAction(obs_source_t *scene)
+{
+	CefRefPtr<CefValue> data = GetScenePropertyValue(
+		scene, ITEM_PRIVATE_DATA_KEY_UI_DEFAULT_ACTION);
+
+	if (data->GetType() != VTYPE_DICTIONARY) {
+		data->SetNull();
+	}
+
+	return data;
+}
+
+void StreamElementsScenesListWidgetManager::SetSceneDefaultAction(
+	obs_source_t *scene, CefRefPtr<CefValue> defaultAction)
+{
+	auto data = SourceDataManager::instance()->data(scene);
+	if (data) {
+		data->DeserializeDefaultAction(defaultAction);
+	}
+
+	SetScenePropertyValue(scene, ITEM_PRIVATE_DATA_KEY_UI_DEFAULT_ACTION,
+			      defaultAction);
+}
+
+CefRefPtr<CefValue>
+StreamElementsScenesListWidgetManager::GetSceneContextMenu(obs_source_t *scene)
+{
+	CefRefPtr<CefValue> data = GetScenePropertyValue(
+		scene, ITEM_PRIVATE_DATA_KEY_UI_CONTEXT_MENU);
+
+	if (data->GetType() != VTYPE_LIST) {
+		data->SetNull();
+	}
+
+	return data;
+}
+
+void StreamElementsScenesListWidgetManager::SetSceneContextMenu(
+	obs_source_t *scene, CefRefPtr<CefValue> contextMenu)
+{
+	auto data = SourceDataManager::instance()->data(scene);
+	if (data) {
+		data->DeserializeContextMenu(contextMenu);
+	}
+
+	SetScenePropertyValue(scene, ITEM_PRIVATE_DATA_KEY_UI_CONTEXT_MENU,
+			      contextMenu);
+}
+
+void StreamElementsScenesListWidgetManager::ScheduleUpdateWidgets()
+{
+	if (!m_enableSignals)
+		return;
+
+	m_updateWidgetsDeferredExecutive.Signal([this]() { UpdateWidgets(); },
+						250);
+}
+
+void StreamElementsScenesListWidgetManager::UpdateScenesToolbar()
+{
+	QtPostTask([=]() {
+		QWidget *widget = m_scenesToolBar->findChild<QWidget *>(
+			"streamelements_scenes_toolbar_aux_actions");
+
+		if (widget)
+			m_scenesToolBar->layout()->removeWidget(widget);
+
+		widget = new QWidget();
+		widget->setObjectName(
+			"streamelements_scenes_toolbar_aux_actions");
+
+		QHBoxLayout *layout = new QHBoxLayout();
+		layout->setContentsMargins(0, 0, 0, 0);
+		widget->setLayout(layout);
+
+		layout->addSpacerItem(new QSpacerItem(
+			16, 16, QSizePolicy::Expanding, QSizePolicy::Minimum));
+
+		if (!m_scenesToolBarActions.get() ||
+		    m_scenesToolBarActions->GetType() != VTYPE_LIST)
+			return;
+
+		CefRefPtr<CefListValue> list =
+			m_scenesToolBarActions->GetList();
+
+		for (size_t index = 0; index < list->GetSize(); ++index) {
+			QWidget *control = DeserializeAuxiliaryControlWidget(
+				list->GetValue(index));
+
+			if (!control)
+				continue;
+
+			layout->addWidget(control);
+			layout->addSpacing(1);
+		}
+
+		widget->setStyleSheet("background: none");
+
+		widget->setSizePolicy(QSizePolicy::Expanding,
+				      QSizePolicy::Minimum);
+
+		m_scenesToolBar->addWidget(widget);
+	});
+}
+
+void StreamElementsScenesListWidgetManager::UpdateWidgets()
+{
+	struct obs_frontend_source_list sources = {};
+
+	obs_frontend_get_scenes(&sources);
+
+	obs_source_t *current_scene = obs_frontend_get_current_scene();
+
+	QtPostTask([=]() {
+		bool isSignedIn =
+			!StreamElementsConfig::GetInstance()->IsOnBoardingMode();
+
+		for (int rowIndex = 0; rowIndex < m_nativeWidget->count() &&
+				       rowIndex < sources.sources.num;
+		     ++rowIndex) {
+			if (!isSignedIn) {
+				m_nativeWidget->item(rowIndex)->setIcon(
+					QIcon());
+
+				continue;
+			}
+
+			obs_source_t *scene = sources.sources.array[rowIndex];
+
+			ItemData *data =
+				SourceDataManager::instance()->data(scene);
+
+			if (!data) {
+				data = new ItemData(
+					[this]() { ScheduleUpdateWidgets(); });
+
+				SourceDataManager::instance()->setData(scene,
+								       data);
+
+				data->DeserializeIcon(GetSceneIcon(scene));
+
+				data->DeserializeDefaultAction(
+					GetSceneDefaultAction(scene));
+
+				data->DeserializeContextMenu(
+					GetSceneContextMenu(scene));
+			}
+
+			m_nativeWidget->item(rowIndex)->setIcon(data->icon());
+		}
+
+		obs_source_release(current_scene);
+
+		obs_frontend_source_list_free(
+			(obs_frontend_source_list *)&sources);
+	});
+}
+
+void StreamElementsScenesListWidgetManager::HandleScenesItemDoubleClicked(
+	QListWidgetItem *item)
+{
+}
+
+bool StreamElementsScenesListWidgetManager::InvokeCurrentSceneDefaultAction()
+{
+	if (!m_nativeWidget)
+		return false;
+
+	QWidget *widget = m_nativeWidget->viewport();
+
+	if (!widget)
+		return false;
+
+	QVariant value =
+		widget->property(WIDGET_PROP_DEFAULT_ACTION_BYPASS_COUNT);
+	if (!value.isValid()) {
+		value.setValue<int>(1);
+	} else {
+		value.setValue<int>(value.value<int>() + 1);
+	}
+
+	widget->setProperty(WIDGET_PROP_DEFAULT_ACTION_BYPASS_COUNT, value);
+
+	QApplication::sendEvent(
+		widget,
+		new QMouseEvent(QMouseEvent::MouseButtonDblClick, QPoint(0, 0),
+				Qt::LeftButton, Qt::NoButton, Qt::NoModifier));
+
+	return true;
+}
+
+bool StreamElementsScenesListWidgetManager::InvokeCurrentSceneDefaultContextMenu()
+{
+	if (!m_nativeWidget)
+		return false;
+
+	const QRect rect =
+		m_nativeWidget->visualRect(m_nativeWidget->currentIndex());
+
+	QtPostTask([=]() {
+		m_nativeWidget->customContextMenuRequested(
+			QPoint(rect.left() + (rect.width() / 2),
+			       rect.top() + (rect.height() / 2)));
+	});
+
+	return true;
+}

--- a/streamelements/StreamElementsScenesListWidgetManager.hpp
+++ b/streamelements/StreamElementsScenesListWidgetManager.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "StreamElementsDeferredExecutive.hpp"
+#include "StreamElementsUtils.hpp"
+
+#include <obs.h>
+
+#include "cef-headers.hpp"
+
+#include <QMainWindow>
+#include <QListWidget>
+#include <QListView>
+#include <QToolBar>
+
+class StreamElementsScenesListWidgetManager : public QObject {
+public:
+	StreamElementsScenesListWidgetManager(QMainWindow *mainWindow);
+	virtual ~StreamElementsScenesListWidgetManager();
+
+public:
+	static CefRefPtr<CefValue> GetScenePropertyValue(obs_source_t *scene,
+							 const char *key);
+
+	void SetScenePropertyValue(obs_source_t *scene, const char *key,
+				   CefRefPtr<CefValue> value,
+				   bool triggerUpdate = true);
+
+	static CefRefPtr<CefValue> GetSceneAuxiliaryData(obs_source_t *scene);
+
+	void SetSceneAuxiliaryData(obs_source_t *scene,
+				   CefRefPtr<CefValue> data);
+
+	static CefRefPtr<CefValue> GetSceneIcon(obs_source_t *scene);
+
+	void SetSceneIcon(obs_source_t *scene, CefRefPtr<CefValue> icon);
+
+	static CefRefPtr<CefValue> GetSceneDefaultAction(obs_source_t *scene);
+
+	void SetSceneDefaultAction(obs_source_t *scene,
+				   CefRefPtr<CefValue> icon);
+
+	static CefRefPtr<CefValue> GetSceneContextMenu(obs_source_t *scene);
+
+	void SetSceneContextMenu(obs_source_t *scene, CefRefPtr<CefValue> icon);
+
+	bool InvokeCurrentSceneDefaultAction();
+	bool InvokeCurrentSceneDefaultContextMenu();
+
+	bool DeserializeScenesAuxiliaryActions(CefRefPtr<CefValue> m_actions)
+	{
+		m_scenesToolBarActions = m_actions->Copy();
+
+		UpdateScenesToolbar();
+
+		return true;
+	}
+
+	void SerializeScenesAuxiliaryActions(CefRefPtr<CefValue> &output)
+	{
+		output = m_scenesToolBarActions->Copy();
+	}
+
+	void Update() { ScheduleUpdateWidgets(); }
+
+	QListWidget *GetScenesListWidget() { return m_nativeWidget; }
+
+private:
+	void HandleScenesModelReset();
+	void HandleScenesModelItemInsertedRemoved(const QModelIndex &, int,
+						  int);
+	void HandleScenesModelItemMoved(const QModelIndex &, int, int,
+					const QModelIndex &, int);
+
+	static void HandleSceneRename(void *data, calldata_t *params);
+
+	void HandleScenesItemDoubleClicked(QListWidgetItem *item);
+
+	void ScheduleUpdateWidgets();
+	void UpdateWidgets();
+
+	void UpdateScenesToolbar();
+
+private:
+	QMainWindow *m_mainWindow = nullptr;
+	QListWidget *m_nativeWidget = nullptr;
+	bool m_enableSignals = false;
+	StreamElementsDeferredExecutive m_updateWidgetsDeferredExecutive;
+	QAbstractItemDelegate *m_editDelegate;
+	QAbstractItemDelegate *m_prevEditDelegate;
+	CefRefPtr<CefValue> m_scenesToolBarActions = CefValue::Create();
+	QToolBar *m_scenesToolBar = nullptr;
+	QObject *m_eventFilter = nullptr;
+};


### PR DESCRIPTION
  * Support icons in auxiliary menu items

  * Support icons for OBS Scene Items (Sources)

  * Support icons for OBS Sources

  * Support auxiliary actions for OBS Scene Items (Sources)

  * Support changing context menu for OBS Scene Items (Sources)

  * Support changing default action (on mouse doubleclick) for OBS
    Scene Items (Sources)

  * Support changing context menu for OBS Scenes

  * Support changing default action (on mouse doubleclick) for OBS
    Scenes

  * Support auxiliary actions in OBS Scene Items (Sources) dock toolbar

  * Support auxiliary actions in OBS Scenes dock toolbar

  * Support auxiliary data for OBS Scenes

  * Support ':defaultAction' and ':defaultContextMenu' invoke macros
    for Scene Item actions, Scene Item default action & Scene Item
    menu items

Add API Methods:

  * invokeCurrentSceneItemDefaultActionById
  * invokeCurrentSceneItemDefaultContextMenuById
  * setCurrentSceneItemsAuxiliaryActions
  * getCurrentSceneItemsAuxiliaryActions
  * setScenesAuxiliaryActions
  * getScenesAuxiliaryActions

Add Data Structures:

  * ActionInfo
  * IconInfo

Add Properties:

  * SceneItemInfo.actions
  * SceneItemInfo.defaultAction
  * SceneItemInfo.contextMenu
  * SceneItemInfo.icon
  * SceneItemInfo.auxiliaryData
  * SceneInfo.icon
  * SceneInfo.defaultAction
  * SceneInfo.contextMenu
  * SceneInfo.auxiliaryData
  * MenuItemInfo.icon

Infrastructure:

  * Support HTTP GET requests with CEF HTTP client

  * Refactor auxiliary menu items deserialization code

  * Add StreamElementsRemoteIconLoader class