### PR TITLE
obs-browser: resolve shutdown instabilities

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -652,12 +652,14 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *)
 		break;
 	case OBS_FRONTEND_EVENT_SCENE_CHANGED: {
 		OBSSource source = obs_frontend_get_current_scene();
-		obs_source_release(source);
 
 		if (!source)
 			break;
 
 		const char *name = obs_source_get_name(source);
+
+		obs_source_release(source);
+
 		if (!name)
 			break;
 

--- a/streamelements/StreamElementsScenesListWidgetManager.cpp
+++ b/streamelements/StreamElementsScenesListWidgetManager.cpp
@@ -237,10 +237,9 @@ protected:
 				handled = DeserializeAndInvokeAction(
 					value, defaultAction,
 					defaultContextMenu);
-
-				if (scene)
-					obs_source_release(scene);
 			}
+
+			obs_source_release(scene);
 
 			return handled;
 		}
@@ -291,8 +290,7 @@ protected:
 				}
 			}
 
-			if (scene)
-				obs_source_release(scene);
+			obs_source_release(scene);
 
 			return handled;
 		}
@@ -325,8 +323,6 @@ StreamElementsScenesListWidgetManager::StreamElementsScenesListWidgetManager(
 	m_eventFilter = new ScenesLocalEventFilter(this);
 
 	QApplication::instance()->installEventFilter(m_eventFilter);
-	//m_nativeWidget->viewport()->installEventFilter(m_eventFilter);
-	//m_nativeWidget->installEventFilter(m_eventFilter);
 
 	m_scenesToolBar =
 		(QToolBar *)scenesDock->findChild<QToolBar *>("scenesToolbar");
@@ -336,7 +332,7 @@ StreamElementsScenesListWidgetManager::StreamElementsScenesListWidgetManager(
 
 	m_scenesToolBarActions->SetNull();
 
-	QtPostTask([this]() {
+	//QtPostTask([this]() {
 		auto model = m_nativeWidget->model();
 
 		/* Subscribe to signals */
@@ -367,21 +363,11 @@ StreamElementsScenesListWidgetManager::StreamElementsScenesListWidgetManager(
 				 &StreamElementsScenesListWidgetManager::
 					 HandleScenesItemDoubleClicked);
 
-		//m_nativeWidget->setVisible(false);
-		//m_nativeWidget->setDisabled(true);
-
-		m_nativeWidget->setEditTriggers(
-			QAbstractItemView::NoEditTriggers);
-
-		//m_editDelegate = new SceneListItemDelegate();
-		//m_prevEditDelegate = m_nativeWidget->itemDelegate();
-		//m_nativeWidget->setItemDelegate(m_editDelegate);
-
 		ScheduleUpdateWidgets();
 		UpdateScenesToolbar();
 
 		m_enableSignals = true;
-	});
+	//});
 }
 
 StreamElementsScenesListWidgetManager::~StreamElementsScenesListWidgetManager()
@@ -657,6 +643,9 @@ void StreamElementsScenesListWidgetManager::UpdateWidgets()
 	obs_frontend_get_scenes(&sources);
 
 	obs_source_t *current_scene = obs_frontend_get_current_scene();
+
+	if (!current_scene)
+		return;
 
 	bool isSignedIn =
 		!StreamElementsConfig::GetInstance()->IsOnBoardingMode();

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -1839,7 +1839,8 @@ bool GetTemporaryFilePath(std::string prefixString, std::string &result)
 std::string GetUniqueFileNameFromPath(std::string path, size_t maxLength)
 {
 	std::string guid = clean_guid_string(CreateGloballyUniqueIdString());
-	std::string ext = os_get_path_extension(path.c_str());
+	const char *ext_cstr = os_get_path_extension(path.c_str());
+	std::string ext = ext_cstr ? ext_cstr : "";
 	std::string result = std::regex_replace(
 		path.substr(0, path.size() - ext.size()) + "_" + guid + ext,
 		std::regex("[\\/: ]"), "_");
@@ -2474,6 +2475,9 @@ void ObsSceneEnumAllItems(obs_scene_t *scene,
 void ObsSceneEnumAllItems(obs_source_t *source,
 			  std::function<bool(obs_sceneitem_t *)> func)
 {
+	if (!source)
+		return;
+
 	obs_scene_t *scene =
 		obs_scene_from_source(source); // does not increment refcount
 
@@ -2483,6 +2487,9 @@ void ObsSceneEnumAllItems(obs_source_t *source,
 void ObsCurrentSceneEnumAllItems(std::function<bool(obs_sceneitem_t *)> func)
 {
 	obs_source_t *sceneSource = obs_frontend_get_current_scene();
+
+	if (!sceneSource)
+		return;
 
 	ObsSceneEnumAllItems(sceneSource, func);
 


### PR DESCRIPTION
* Subscribe to all Scene signals instead of Active scene signals only

* Move shutdown check to OBS.Live event dispatchers

* Resolve deadlock with NetworkDialog shutdown when network call is in
  progress

* Balance obs_source_addref / obs_source_release in Scene list manager

* Balance obs_sceneitem_addref / obs_sceneitem_release in Scene Items
  list manager

* Add check for null file name extension to `GetUniqueFileNameFromPath`

* Add NULL checks

Add Events:

	* hostSceneItemAdded
	* hostSceneItemListChanged
	* hostSceneItemOrderChanged
	* hostSceneItemPropertiesChanged
	* hostSceneItemRemoved
	* hostSceneItemRenamed
	* hostSceneItemSelected
	* hostSceneItemSettingsChanged
	* hostSceneItemTransformed
	* hostSceneItemUnselected