### PR TITLE
obs-browser: hotfix: alt+source crop + scene collection switch crash

### DIFF
--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -2503,3 +2503,36 @@ bool IsCefValueEqual(CefRefPtr<CefValue> a, CefRefPtr<CefValue> b)
 
 	return json1 == json2;
 }
+
+void ObsEnumAllScenes(std::function < bool(obs_source_t * scene)> func)
+{
+	struct local_context {
+		std::vector<obs_source_t *> list;
+	};
+
+	local_context context;
+
+	obs_enum_scenes(
+		[](void *data, obs_source_t *scene) -> bool {
+			local_context *context = (local_context *)data;
+
+			
+			if (!obs_source_is_group(scene)) {
+				obs_source_addref(scene);
+
+				context->list.push_back(scene);
+			}
+
+			return true;
+		},
+		&context);
+
+	for (auto scene : context.list) {
+		if (!func(scene))
+			break;
+	}
+
+	for (auto scene : context.list) {
+		obs_source_release(scene);
+	}
+}

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -303,3 +303,7 @@ void ObsCurrentSceneEnumAllItems(std::function<bool(obs_sceneitem_t *)> func);
 /* ========================================================= */
 
 bool IsCefValueEqual(CefRefPtr<CefValue> a, CefRefPtr<CefValue> b);
+
+/* ========================================================= */
+
+void ObsEnumAllScenes(std::function<bool(obs_source_t *scene)> func);


### PR DESCRIPTION
* Resolve deadlock when Alt+Source click is used to crop a source

* Resolve issue with obs_frontend_get_scenes() API when switching
  scene collections (replace with obs_enum_scenes() while checking
  that obs_source_is_group() == false)