### PR TITLE
obs-browser: API 1.27: bg workers script injection

### DIFF
--- a/streamelements/StreamElementsCefClient.hpp
+++ b/streamelements/StreamElementsCefClient.hpp
@@ -34,6 +34,7 @@ class StreamElementsCefClient : public CefClient,
 				public CefDisplayHandler,
 				public CefKeyboardHandler,
 				public CefRequestHandler,
+				public CefRenderHandler,
 #if CHROME_VERSION_BUILD >= 3770
 				public CefResourceRequestHandler,
 #endif
@@ -129,6 +130,10 @@ public:
 		return this;
 	}
 	virtual CefRefPtr<CefDragHandler> GetDragHandler() override
+	{
+		return this;
+	}
+	virtual CefRefPtr<CefRenderHandler> GetRenderHandler() override
 	{
 		return this;
 	}
@@ -362,6 +367,34 @@ public:
 				   const CefKeyEvent &event,
 				   CefEventHandle os_event,
 				   bool *is_keyboard_shortcut) override;
+
+	/* CefRenderHandler */
+#if CHROME_VERSION_BUILD >= 3578
+	virtual void GetViewRect(
+#else
+	virtual bool GetViewRect(
+#endif
+		CefRefPtr<CefBrowser> browser, CefRect &rect) override
+	{
+		rect.Set(0, 0, 1920, 1080);
+	}
+
+	virtual void OnPaint(CefRefPtr<CefBrowser> browser,
+			     PaintElementType type, const RectList &dirtyRects,
+			     const void *buffer, int width, int height) override
+	{
+		// NOOP
+	}
+
+#if EXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED
+	virtual void OnAcceleratedPaint(CefRefPtr<CefBrowser> browser,
+					PaintElementType type,
+					const RectList &dirtyRects,
+					void *shared_handle) override
+	{
+		// NOOP
+	}
+#endif
 
 public:
 	std::string GetExecuteJavaScriptCodeOnLoad()

--- a/streamelements/StreamElementsObsSceneManager.cpp
+++ b/streamelements/StreamElementsObsSceneManager.cpp
@@ -19,6 +19,9 @@
 //            are fixed, change this to 1
 #define ENABLE_OBS_GROUP_ADD_REMOVE_ITEM 0
 
+// obs_scene_get_group deadlocks on full_lock(scene) when inside a scene signal handler
+#define ENABLE_GET_GROUP_SCENE_IN_SIGNAL_HANDLER 0
+
 bool s_shutdown = false;
 
 ///////////////////////////////////////////////////////////////////////////
@@ -55,6 +58,7 @@ static bool is_child_of_current_scene(obs_sceneitem_t* sceneitem)
 		if (root_scene == parent_scene)
 			result = true;
 	} else {
+#if ENABLE_GET_GROUP_SCENE_IN_SIGNAL_HANDLER
 		// how to get parent scene?!
 		obs_source_t* group_source = obs_scene_get_source(parent_scene);
 
@@ -64,6 +68,7 @@ static bool is_child_of_current_scene(obs_sceneitem_t* sceneitem)
 
 		if (group_sceneitem)
 			result = true;
+#endif
 	}
 
 	obs_source_release(root_scene_source);

--- a/streamelements/StreamElementsWorkerManager.hpp
+++ b/streamelements/StreamElementsWorkerManager.hpp
@@ -22,7 +22,8 @@ public:
 
 public:
 	void RemoveAll();
-	std::string Add(std::string requestedId, std::string content, std::string url);
+	std::string Add(std::string requestedId, std::string content,
+			std::string url, std::string executeJavascriptOnLoad);
 	void Remove(std::string id);
 	std::string GetContent(std::string id);
 	void GetIdentifiers(std::vector<std::string>& result);

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 26
+#define HOST_API_VERSION_MINOR 27
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
Infrastructure:

  * Increase background worker canvas size from 100x100 to 1920x1080

  * Create background workers in windowless mode (always "visible")

  * Disable 'hostCurrentSceneItemXXX' events for group items due to
    deadlock in `obs_scene_get_group` while inside signal handler

Add Properties:

  * BackgroundWorkerInfo.executeJavaScriptOnLoad