### PR TITLE
obs-browser: API 1.29: query updates API

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,8 @@ install:
 
     cinst -y curl
 
+    git clone https://github.com/KhronosGroup/Vulkan-Hpp.git c:\local\Vulkan-Hpp
+
     git clone --recursive https://github.com/jp9000/obs-studio.git c:\local\obs-studio
 
     cd /d c:\local\obs-studio
@@ -88,9 +90,9 @@ install:
 
     set VLCPath=c:\local\vlc
 
-    set QTDIR32=C:\Qt\5.10.1\msvc2015
+    set QTDIR32=C:\Qt\5.13.2\msvc2017
 
-    set QTDIR64=C:\Qt\5.10.1\msvc2017_64
+    set QTDIR64=C:\Qt\5.13.2\msvc2017_64
 
     set build_config=RelWithDebInfo
 cache:
@@ -155,7 +157,7 @@ build_script:
 
     cd /d c:\local\obs-studio\build64
 
-    "C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 15 2017 Win64" -DEXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED=true -DBROWSER_PANEL_SUPPORT_ENABLED=true -DENABLE_SCRIPTING=false -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DCOMPILE_D3D12_HOOK=true -DCEF_ROOT_DIR=c:\local\cef_binary_%PREBUILT_CEF_VERSION%_windows64_minimal -DBUGSPLAT_ROOT_DIR=c:\local\BugSplat -DANGELSCRIPT_ROOT_DIR=c:\local\angelscript ..
+    "C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 15 2017 Win64" -DEXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED=true -DBROWSER_PANEL_SUPPORT_ENABLED=true -DENABLE_SCRIPTING=false -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DCOMPILE_D3D12_HOOK=true -DCEF_ROOT_DIR=c:\local\cef_binary_%PREBUILT_CEF_VERSION%_windows64_minimal -DBUGSPLAT_ROOT_DIR=c:\local\BugSplat -DANGELSCRIPT_ROOT_DIR=c:\local\angelscript -DQTDIR=%QTDIR64% -DQt5Widgets_DIR=%QTDIR64%\lib\cmake\Qt5Widgets -DQt5Xml_DIR=%QTDIR64%\lib\cmake\Qt5Xml -DQt5Svg_DIR=%QTDIR64%\lib\cmake\Qt5Svg -DENABLE_UI=true -DVULKAN_INCLUDE_DIR=C:\local\Vulkan-Hpp -DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.18362.0 -DCMAKE_SYSTEM_VERSION=10.0.18362.0 ..
 
     cd /d c:\local\obs-studio\build64
 
@@ -200,7 +202,7 @@ build_script:
 
     cd /d c:\local\obs-studio\build32
 
-    "C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 15 2017" -DEXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED=true -DBROWSER_PANEL_SUPPORT_ENABLED=true -DENABLE_SCRIPTING=false -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DCOMPILE_D3D12_HOOK=true -DCEF_ROOT_DIR=c:\local\cef_binary_%PREBUILT_CEF_VERSION%_windows32_minimal -DBUGSPLAT_ROOT_DIR=c:\local\BugSplat -DANGELSCRIPT_ROOT_DIR=c:\local\angelscript ..
+    "C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 15 2017" -DEXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED=true -DBROWSER_PANEL_SUPPORT_ENABLED=true -DENABLE_SCRIPTING=false -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DCOMPILE_D3D12_HOOK=true -DCEF_ROOT_DIR=c:\local\cef_binary_%PREBUILT_CEF_VERSION%_windows32_minimal -DBUGSPLAT_ROOT_DIR=c:\local\BugSplat -DANGELSCRIPT_ROOT_DIR=c:\local\angelscript -DQTDIR=%QTDIR32% -DQt5Widgets_DIR=%QTDIR32%\lib\cmake\Qt5Widgets -DQt5Xml_DIR=%QTDIR32%\lib\cmake\Qt5Xml -DQt5Svg_DIR=%QTDIR32%\lib\cmake\Qt5Svg -DENABLE_UI=true -DVULKAN_INCLUDE_DIR=C:\local\Vulkan-Hpp -DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.18362.0 -DCMAKE_SYSTEM_VERSION=10.0.18362.0 ..
 
     cd /d c:\local\obs-studio\build32
 

--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -1459,10 +1459,49 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 
 	API_HANDLER_BEGIN("queryHostReleaseGroupUpdateAvailability");
 	{
+		bool allowDowngrade = false;
+		bool forceInstall = false;
+		bool allowUseLastResponse = true;
+
+		if (args->GetSize() > 0) {
+			if (args->GetValue(0)->GetType() == VTYPE_DICTIONARY) {
+				CefRefPtr<CefDictionaryValue> d =
+					args->GetDictionary(0);
+
+				if (d->HasKey("allowDowngrade") &&
+				    d->GetType("allowDowngrade") ==
+					    VTYPE_BOOL) {
+					allowDowngrade =
+						d->GetBool("allowDowngrade");
+				}
+
+				if (d->HasKey("forceInstall") &&
+				    d->GetType("forceInstall") ==
+					    VTYPE_BOOL) {
+					forceInstall =
+						d->GetBool("forceInstall");
+				}
+
+				if (d->HasKey("allowUseLastResponse") &&
+				    d->GetType("allowUseLastResponse") == VTYPE_BOOL) {
+					allowUseLastResponse =
+						d->GetBool("allowUseLastResponse");
+				}
+			}
+		}
+
+		calldata_t *cd = calldata_create();
+		calldata_set_bool(cd, "allow_downgrade", allowDowngrade);
+		calldata_set_bool(cd, "force_install", forceInstall);
+		calldata_set_bool(cd, "allow_use_last_response",
+				  allowUseLastResponse);
+
 		signal_handler_signal(
 			obs_get_signal_handler(),
 			"streamelements_request_check_for_updates_silent",
-			nullptr);
+			cd);
+
+		calldata_free(cd);
 
 		result->SetBool(true);
 	}

--- a/streamelements/StreamElementsDeferredExecutive.hpp
+++ b/streamelements/StreamElementsDeferredExecutive.hpp
@@ -3,6 +3,7 @@
 #include <QTimer>
 
 #include <mutex>
+#include <functional>
 
 class StreamElementsDeferredExecutive
 {

--- a/streamelements/StreamElementsExternalSceneDataProviderSlobsClient.hpp
+++ b/streamelements/StreamElementsExternalSceneDataProviderSlobsClient.hpp
@@ -20,7 +20,8 @@ public:
 
 			std::replace(m_basePath.begin(), m_basePath.end(), '\\', '/');
 
-			if (!std::experimental::filesystem::is_directory(m_basePath)) {
+			if (!std::experimental::filesystem::is_directory(
+				    m_basePath)) {
 				blog(LOG_INFO,
 					"obs-browser: StreamElementsExternalSceneDataProviderSlobsClient: path does not exist: %s",
 					m_basePath.c_str());

--- a/streamelements/StreamElementsFileSystemMapper.hpp
+++ b/streamelements/StreamElementsFileSystemMapper.hpp
@@ -42,10 +42,13 @@ public:
 	StreamElementsFileSystemMapper(std::string rootFolderPath) :
 		m_rootFolderPath(rootFolderPath)
 	{
-		for (auto& p : std::experimental::filesystem::directory_iterator(rootFolderPath)) {
+		for (auto &p :
+		     std::experimental::filesystem::directory_iterator(
+			     rootFolderPath)) {
 			std::wstring path = p.path();
 
-			if (!std::experimental::filesystem::is_regular_file(path)) {
+			if (!std::experimental::filesystem::is_regular_file(
+				    path)) {
 				continue;
 			}
 
@@ -127,13 +130,13 @@ public:
 			absolute_path = path;
 
 			return true;
-		}
-		else if (std::experimental::filesystem::is_regular_file(path + ".html")) {
+		} else if (std::experimental::filesystem::is_regular_file(
+				   path + ".html")) {
 			absolute_path = path + ".html";
 
 			return true;
-		}
-		else if (std::experimental::filesystem::is_regular_file(path + "/index.html")) {
+		} else if (std::experimental::filesystem::is_regular_file(
+				   path + "/index.html")) {
 			absolute_path = path + "/index.html";
 
 			return true;

--- a/streamelements/StreamElementsLocalWebFilesServer.cpp
+++ b/streamelements/StreamElementsLocalWebFilesServer.cpp
@@ -198,7 +198,8 @@ StreamElementsLocalWebFilesServer::StreamElementsLocalWebFilesServer(std::string
 
 	std::wstring_convert<std::codecvt_utf8<wchar_t>> myconv;
 
-	for (auto& p : std::experimental::filesystem::directory_iterator(m_rootFolder)) {
+	for (auto &p :
+	     std::experimental::filesystem::directory_iterator(m_rootFolder)) {
 		std::string path = myconv.to_bytes(p.path().c_str());
 
 		if (std::experimental::filesystem::is_directory(path)) {

--- a/streamelements/StreamElementsMenuManager.cpp
+++ b/streamelements/StreamElementsMenuManager.cpp
@@ -184,10 +184,17 @@ void StreamElementsMenuManager::Update()
 	m_menu->addAction(check_for_updates_action);
 	check_for_updates_action->connect(
 		check_for_updates_action, &QAction::triggered, [this] {
+			calldata_t *cd = calldata_create();
+			calldata_set_bool(cd, "allow_downgrade", false);
+			calldata_set_bool(cd, "force_install", false);
+			calldata_set_bool(cd, "allow_use_last_response", false);
+
 			signal_handler_signal(
 				obs_get_signal_handler(),
 				"streamelements_request_check_for_updates",
-				nullptr);
+				cd);
+
+			calldata_free(cd);
 		});
 
 	m_menu->addSeparator();

--- a/streamelements/StreamElementsReportIssueDialog.cpp
+++ b/streamelements/StreamElementsReportIssueDialog.cpp
@@ -439,8 +439,11 @@ void StreamElementsReportIssueDialog::accept()
 			};
 
 			// Collect all files
-			for (auto& i : std::experimental::filesystem::recursive_directory_iterator(programDataPathBuf)) {
-				if (!std::experimental::filesystem::is_directory(i.path())) {
+			for (auto &i : std::experimental::filesystem::
+				     recursive_directory_iterator(
+					     programDataPathBuf)) {
+				if (!std::experimental::filesystem::is_directory(
+					    i.path())) {
 					std::wstring local_path = i.path().c_str();
 					std::wstring zip_path = local_path.substr(obsDataPath.size() + 1);
 

--- a/streamelements/deps/server/NamedPipesServerClientHandler.hpp
+++ b/streamelements/deps/server/NamedPipesServerClientHandler.hpp
@@ -5,6 +5,7 @@
 #include <thread>
 #include <mutex>
 #include <vector>
+#include <functional>
 #include "streamelements/deps/moodycamel/blockingconcurrentqueue.h"
 
 // Single named pipes client handler.

--- a/streamelements/restore-script-host/ScriptEngine.cpp
+++ b/streamelements/restore-script-host/ScriptEngine.cpp
@@ -304,7 +304,7 @@ ScriptEngine::ScriptEngine()
 		asFUNCTION(ui_error), asCALL_CDECL);
 }
 
-ScriptEngine ::~ScriptEngine()
+ScriptEngine::~ScriptEngine()
 {
 	m_engine->ShutDownAndRelease();
 }
@@ -352,6 +352,8 @@ bool ScriptEngine::ExecuteString(const char *script)
 
 		mod->Discard();
 	}
+
+	return result;
 }
 
 bool ScriptEngine::ExecuteFile(const char *path)


### PR DESCRIPTION
Support upcoming OBS 25

  * Add Windows SDK setting to CMake command-line

  * Add Vulkan include files

  * Build with Qt 5.13.2

Modify API Methods:

  * queryHostReleaseGroupUpdateAvailability

Add Data Structures:

  * QuerySoftwareUpdateArgs