### PR TITLE
obs-browser: fix source default action behavior & grid mode support

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -1900,4 +1900,6 @@ bool StreamElementsApiMessageHandler::InvokeHandler::InvokeApiCallAsync(
 			delete context;
 		},
 		context);
+
+	return true;
 }

--- a/streamelements/StreamElementsSceneItemsMonitor.cpp
+++ b/streamelements/StreamElementsSceneItemsMonitor.cpp
@@ -119,6 +119,15 @@ public:
 		if (!mouse && !contextMenu)
 			return false;
 
+		if (target->objectName() == QString("preview")) {
+			/* OBS preview pane */
+			if (e->type() == QEvent::ContextMenu) {
+				// TODO: TBD: Handle context menu for preview window events
+			}
+
+			return false; // not handled
+		}
+
 		/* Make sure events belong to QListView item widgets */
 		if (!target->parent() ||
 		    !m_monitor->GetSceneItemsListView()->viewport() ||

--- a/streamelements/StreamElementsScenesListWidgetManager.hpp
+++ b/streamelements/StreamElementsScenesListWidgetManager.hpp
@@ -64,6 +64,8 @@ public:
 
 	QListWidget *GetScenesListWidget() { return m_nativeWidget; }
 
+	void CheckViewMode();
+
 private:
 	void HandleScenesModelReset();
 	void HandleScenesModelItemInsertedRemoved(const QModelIndex &, int,
@@ -90,4 +92,5 @@ private:
 	CefRefPtr<CefValue> m_scenesToolBarActions = CefValue::Create();
 	QToolBar *m_scenesToolBar = nullptr;
 	QObject *m_eventFilter = nullptr;
+	QListWidget::ViewMode m_prevViewMode = QListView::ListMode;
 };


### PR DESCRIPTION
* `StreamElementsApiMessageHandler::InvokeHandler::InvokeApiCallAsync`
  would not always return a predictable result on success. This caused
  default action override to be followed by OBS native default action.

* OBS 25 adds Grid Mode to scenes list. When grid mode is active, we
  must disable Scene icons since grid cells are fixed height, and icons
  are being displayed above the text causing the text to be shifted
  down where only a portion of it is visible.