### PR TITLE
obs-browser: API 1.32 scene coll & profile events

### DIFF
--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -197,6 +197,18 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 	case OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED:
 		name = "hostSceneListChanged";
 		break;
+	case OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED:
+		name = "hostSceneCollectionChanged";
+		break;
+	case OBS_FRONTEND_EVENT_SCENE_COLLECTION_LIST_CHANGED:
+		name = "hostSceneCollectionListChanged";
+		break;
+	case OBS_FRONTEND_EVENT_PROFILE_CHANGED:
+		name = "hostProfileChanged";
+		break;
+	case OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED:
+		name = "hostProfileListChanged";
+		break;
 	case OBS_FRONTEND_EVENT_EXIT:
 		name = "hostExit";
 		break;

--- a/streamelements/StreamElementsObsSceneManager.cpp
+++ b/streamelements/StreamElementsObsSceneManager.cpp
@@ -2637,29 +2637,6 @@ void StreamElementsObsSceneManager::SetObsSceneItemPropertiesById(
 						 d->GetBool("locked"));
 		}
 
-		if (d->HasKey("order") && d->GetType("order") == VTYPE_INT) {
-			int order = d->GetInt("order");
-
-			auto update = [&]() -> void {
-				if (!obs_sceneitem_get_scene(context.sceneitem))
-					return;
-
-				obs_sceneitem_set_order_position(
-					context.sceneitem, order);
-			};
-
-			using update_t = decltype(update);
-
-			obs_enter_graphics();
-			obs_scene_atomic_update(
-				scene,
-				[](void *data, obs_scene_t *) {
-					(*reinterpret_cast<update_t *>(data))();
-				},
-				&update);
-			obs_leave_graphics();
-		}
-
 #if ENABLE_OBS_GROUP_ADD_REMOVE_ITEM
 		// This piece of code just does not work. It seems that
 		// the implementation of `obs_sceneitem_group_remove_item`
@@ -2711,6 +2688,29 @@ void StreamElementsObsSceneManager::SetObsSceneItemPropertiesById(
 			}
 		}
 #endif
+
+		if (d->HasKey("order") && d->GetType("order") == VTYPE_INT) {
+			int order = d->GetInt("order");
+
+			auto update = [&]() -> void {
+				if (!obs_sceneitem_get_scene(context.sceneitem))
+					return;
+
+				obs_sceneitem_set_order_position(
+					context.sceneitem, order);
+			};
+
+			using update_t = decltype(update);
+
+			obs_enter_graphics();
+			obs_scene_atomic_update(
+				scene,
+				[](void *data, obs_scene_t *) {
+					(*reinterpret_cast<update_t *>(data))();
+				},
+				&update);
+			obs_leave_graphics();
+		}
 
 		// Result
 		SerializeSourceAndSceneItem(output, source, context.sceneitem);

--- a/streamelements/StreamElementsScenesListWidgetManager.cpp
+++ b/streamelements/StreamElementsScenesListWidgetManager.cpp
@@ -137,6 +137,26 @@ public:
 		m_itemData.erase(key);
 	}
 
+	void removeDataNotInList(obs_frontend_source_list sources)
+	{
+		std::unordered_map<obs_source_t *, bool> sourcesMap;
+		for (size_t i = 0; i < sources.sources.num; ++i) {
+			sourcesMap[sources.sources.array[i]] = true;
+		}
+
+		std::vector<obs_source_t *> deleteList;
+
+		for (auto kv : m_itemData) {
+			if (!sourcesMap.count(kv.first)) {
+				deleteList.emplace_back(kv.first);
+			}
+		}
+
+		for (obs_source_t *key : deleteList) {
+			removeData(key);
+		}
+	}
+
 	void setData(obs_source_t *key, ItemData *value)
 	{
 		removeData(key);
@@ -673,6 +693,8 @@ void StreamElementsScenesListWidgetManager::UpdateWidgets()
 
 	bool isSignedIn =
 		!StreamElementsConfig::GetInstance()->IsOnBoardingMode();
+
+	SourceDataManager::instance()->removeDataNotInList(sources);
 
 	for (int rowIndex = 0; rowIndex < m_nativeWidget->count() &&
 				rowIndex < sources.sources.num;

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 30
+#define HOST_API_VERSION_MINOR 32
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
obs-browser: API 1.32 scene coll & profile events

Add Events:

  * hostSceneCollectionChanged
  * hostSceneCollectionListChanged
  * hostProfileChanged
  * hostProfileListChanged

Bugfixes:

  * Scene Items API: Adjust scene item `order` before adjusting it's
    `parentId` (group) caused a crash
  
  * Remove application data associated with removed Scenes when Scene
    no longer exists