### PR TITLE
obs-browser: API 1.32: add scene item UI settings

### DIFF
--- a/streamelements/StreamElementsObsSceneManager.hpp
+++ b/streamelements/StreamElementsObsSceneManager.hpp
@@ -19,6 +19,15 @@ public:
 	virtual ~StreamElementsObsSceneManager();
 
 public:
+	void Update()
+	{
+		if (m_sceneItemsMonitor)
+			m_sceneItemsMonitor->Update();
+
+		if (m_scenesWidgetManager)
+			m_scenesWidgetManager->Update();
+	}
+
 	void Reset()
 	{
 		DeserializeSceneItemsAuxiliaryActions(CefValue::Create(),
@@ -27,11 +36,7 @@ public:
 		DeserializeScenesAuxiliaryActions(CefValue::Create(),
 						  CefValue::Create());
 
-		if (m_sceneItemsMonitor)
-			m_sceneItemsMonitor->Update();
-
-		if (m_scenesWidgetManager)
-			m_scenesWidgetManager->Update();
+		Update();
 	}
 
 	/* Sources */

--- a/streamelements/StreamElementsSceneItemsMonitor.hpp
+++ b/streamelements/StreamElementsSceneItemsMonitor.hpp
@@ -10,6 +10,7 @@
 #include <QAbstractItemModel>
 #include <QToolBar>
 #include <QListWidget>
+#include <QToolButton>
 
 #include <obs.h>
 
@@ -59,6 +60,18 @@ public:
 		obs_sceneitem_t *scene_item);
 
 	void SetSceneItemAuxiliaryData(obs_sceneitem_t *scene_item,
+				       CefRefPtr<CefValue> data);
+
+	CefRefPtr<CefValue> static GetSceneItemUISettings(
+		obs_sceneitem_t *scene_item);
+
+	bool static GetSceneItemUISettingsEnabled(
+		obs_sceneitem_t *scene_item);
+
+	bool static GetSceneItemUISettingsMultiselectContextMenuEnabled(
+		obs_sceneitem_t *scene_item);
+
+	void SetSceneItemUISettings(obs_sceneitem_t *scene_item,
 				       CefRefPtr<CefValue> data);
 
 	bool InvokeCurrentSceneItemDefaultAction(obs_sceneitem_t *scene_item);
@@ -116,14 +129,12 @@ protected:
 private:
 	QMainWindow *m_mainWindow;
 	QListView *m_sceneItemsListView = nullptr;
-	//QListView *m_scenesListView = nullptr;
-	//QListWidget *m_scenesListWidget = nullptr;
 	QToolBar *m_sceneItemsToolBar = nullptr;
 	QAbstractItemModel *m_sceneItemsModel = nullptr;
-	//QAbstractItemModel *m_scenesModel = nullptr;
 	bool m_enableSignals = false;
 	StreamElementsDeferredExecutive
 		m_updateSceneItemsWidgetsThrottledExecutive;
 	QObject *m_eventFilter = nullptr;
 	CefRefPtr<CefValue> m_sceneItemsToolBarActions = CefValue::Create();
+	QToolButton *m_nativeActionSourcePropertiesButton = nullptr;
 };

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -2287,6 +2287,15 @@ DeserializeAuxiliaryControlWidget(CefRefPtr<CefValue> input,
 		}
 	}
 
+	std::string styleSheet =
+		"QToolTip { color: #eeeeee; background-color: #000000; } ";
+
+	if (d->HasKey("color") && d->GetType("color") == VTYPE_STRING) {
+		styleSheet += "QPushButton { color: ";
+		styleSheet += d->GetString("color").ToString() + ";";
+		styleSheet += " }";
+	}
+
 	if (type == "container") {
 		if (!d->HasKey("items") || d->GetType("items") != VTYPE_LIST)
 			return nullptr;
@@ -2324,8 +2333,7 @@ DeserializeAuxiliaryControlWidget(CefRefPtr<CefValue> input,
 			control->setToolTip(tooltip.c_str());
 		}
 
-		control->setStyleSheet(
-			"QToolTip { color: #eeeeee; background-color: #000000; }");
+		control->setStyleSheet(styleSheet.c_str());
 
 		QObject::connect(control, &QPushButton::clicked, HandleClick);
 
@@ -2364,8 +2372,7 @@ DeserializeAuxiliaryControlWidget(CefRefPtr<CefValue> input,
 			control->setToolTip(tooltip.c_str());
 		}
 
-		control->setStyleSheet(
-			"QToolTip { color: #eeeeee; background-color: #000000; }");
+		control->setStyleSheet(styleSheet.c_str());
 
 		QObject::connect(control, &QPushButton::clicked, HandleClick);
 
@@ -2424,6 +2431,9 @@ bool DeserializeAndInvokeAction(CefRefPtr<CefValue> input,
 	} else if (invoke == ":defaultContextMenu") {
 		defaultContextMenu();
 
+		return true;
+	} else if (invoke == ":none") {
+		// No action
 		return true;
 	} else {
 		return StreamElementsApiMessageHandler::InvokeHandler::


### PR DESCRIPTION
Add API to disable scene items in OBS Sources list, set scene items'
opacity in OBS Sources list, and the option to disable scene items'
context menu when multiple scene items are selected.

Add API to disable default action for scene items.

Enable/disable scene item properties cogwheel in OBS Sources list
according to selection items state.

Add Properties:

  * SceneItemInfo.uiSettings.enabled
  * SceneItemInfo.uiSettings.opacity
  * SceneItemInfo.uiSettings.multipleItemsContextMenuEnabled
  * ActionInfo.color

Add Property Values:

  * ActionInfo.invoke = ":none"