### PR TITLE
obs-browser: API 1.35: add batch API support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ set(obs-browser_SOURCES
 	streamelements/StreamElementsDeferredExecutive.cpp
 	streamelements/StreamElementsRemoteIconLoader.cpp
 	streamelements/StreamElementsScenesListWidgetManager.cpp
+	streamelements/StreamElementsPleaseWaitWindow.cpp
 	streamelements/deps/StackWalker/StackWalker.cpp
 	streamelements/deps/zip/zip.c
 	streamelements/deps/server/NamedPipesServer.cpp
@@ -241,6 +242,7 @@ set(obs-browser_HEADERS
 	streamelements/StreamElementsDeferredExecutive.hpp
 	streamelements/StreamElementsRemoteIconLoader.hpp
 	streamelements/StreamElementsScenesListWidgetManager.hpp
+	streamelements/StreamElementsPleaseWaitWindow.hpp
 	streamelements/deps/StackWalker/StackWalker.h
 	streamelements/deps/zip/zip.h
 	streamelements/deps/zip/miniz.h

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -65,7 +65,7 @@ static void SendBrowserVisibility(CefRefPtr<CefBrowser> browser, bool isVisible)
 void DispatchJSEvent(std::string eventName, std::string jsonString,
 		     BrowserSource *browser = nullptr);
 
-BrowserSource::BrowserSource(obs_data_t *, obs_source_t *source_)
+BrowserSource::BrowserSource(obs_data_t *settings, obs_source_t *source_)
 	: source(source_)
 {
 	{
@@ -74,6 +74,11 @@ BrowserSource::BrowserSource(obs_data_t *, obs_source_t *source_)
 			handler,
 			"void streamelements_update_settings(ptr source)");
 	}
+
+	/* init source dimensions upfront: they are used to make sure
+	 * the source was indeed initialized */
+	width = (int)obs_data_get_int(settings, "width");
+	height = (int)obs_data_get_int(settings, "height");
 
 	/* defer update */
 	obs_source_update(source, nullptr);

--- a/streamelements/StreamElementsApiMessageHandler.hpp
+++ b/streamelements/StreamElementsApiMessageHandler.hpp
@@ -33,11 +33,18 @@ protected:
 		StreamElementsApiMessageHandler *,
 		CefRefPtr<CefProcessMessage> message,
 		CefRefPtr<CefListValue> args, CefRefPtr<CefValue> &result,
-		CefRefPtr<CefBrowser> browser, void (*complete)(void *),
-		void *context);
+		CefRefPtr<CefBrowser> browser, const long cefClientId, std::function<void()> complete_callback);
 
 	void RegisterIncomingApiCallHandler(std::string id,
 					    incoming_call_handler_t handler);
+
+	void InvokeApiCallHandlerAsync(
+		CefRefPtr<CefProcessMessage> message,
+		CefRefPtr<CefBrowser> browser, std::string invokeId,
+		CefRefPtr<CefListValue> invokeArgs,
+		std::function<void(CefRefPtr<CefValue>)> result_callback,
+		const long cefClientId,
+		const bool enable_logging = false);
 
 private:
 	std::map<std::string, incoming_call_handler_t> m_apiCallHandlers;

--- a/streamelements/StreamElementsBrowserDialog.cpp
+++ b/streamelements/StreamElementsBrowserDialog.cpp
@@ -7,8 +7,8 @@
 
 static std::recursive_mutex s_sync_api_call_mutex;
 
-#define API_HANDLER_BEGIN(name) RegisterIncomingApiCallHandler(name, [](StreamElementsApiMessageHandler* self, CefRefPtr<CefProcessMessage> message, CefRefPtr<CefListValue> args, CefRefPtr<CefValue>& result, CefRefPtr<CefBrowser> browser, void (*complete_callback)(void*), void* complete_context) { std::lock_guard<std::recursive_mutex> _api_sync_guard(s_sync_api_call_mutex);
-#define API_HANDLER_END() complete_callback(complete_context); });
+#define API_HANDLER_BEGIN(name) RegisterIncomingApiCallHandler(name, [](StreamElementsApiMessageHandler* self, CefRefPtr<CefProcessMessage> message, CefRefPtr<CefListValue> args, CefRefPtr<CefValue>& result, CefRefPtr<CefBrowser> browser, const long cefClientId, std::function<void()> complete_callback) { std::lock_guard<std::recursive_mutex> _api_sync_guard(s_sync_api_call_mutex);
+#define API_HANDLER_END() complete_callback(); });
 
 class StreamElementsDialogApiMessageHandler : public StreamElementsApiMessageHandler
 {

--- a/streamelements/StreamElementsBrowserSourceApiMessageHandler.cpp
+++ b/streamelements/StreamElementsBrowserSourceApiMessageHandler.cpp
@@ -5,8 +5,8 @@
 
 static std::recursive_mutex s_sync_api_call_mutex;
 
-#define API_HANDLER_BEGIN(name) RegisterIncomingApiCallHandler(name, [](StreamElementsApiMessageHandler*, CefRefPtr<CefProcessMessage> message, CefRefPtr<CefListValue> args, CefRefPtr<CefValue>& result, CefRefPtr<CefBrowser> browser, void (*complete_callback)(void*), void* complete_context) { std::lock_guard<std::recursive_mutex> _api_sync_guard(s_sync_api_call_mutex);
-#define API_HANDLER_END() complete_callback(complete_context); });
+#define API_HANDLER_BEGIN(name) RegisterIncomingApiCallHandler(name, [](StreamElementsApiMessageHandler*, CefRefPtr<CefProcessMessage> message, CefRefPtr<CefListValue> args, CefRefPtr<CefValue>& result, CefRefPtr<CefBrowser> browser, const long cefClientId, std::function<void()> complete_callback) { std::lock_guard<std::recursive_mutex> _api_sync_guard(s_sync_api_call_mutex);
+#define API_HANDLER_END() complete_callback(); });
 
 StreamElementsBrowserSourceApiMessageHandler::StreamElementsBrowserSourceApiMessageHandler()
 {

--- a/streamelements/StreamElementsHotkeyManager.cpp
+++ b/streamelements/StreamElementsHotkeyManager.cpp
@@ -1,5 +1,6 @@
 #include "StreamElementsHotkeyManager.hpp"
 #include "StreamElementsCefClient.hpp"
+#include "StreamElementsUtils.hpp"
 
 #include <util/dstr.h>
 #include <obs-module.h>
@@ -114,7 +115,7 @@ static CefRefPtr<CefDictionaryValue> SerializeKeyCombination(obs_key_combination
 
 void StreamElementsHotkeyManager::hotkey_change_handler(void*, calldata_t*)
 {
-	StreamElementsCefClient::DispatchJSEvent("hostHotkeyBindingsChanged", "null");
+	AdviseHostHotkeyBindingsChanged();
 }
 
 static const char* HOTKEY_BINDINGS_CHANGED_SIGNAL_NAMES[] = {

--- a/streamelements/StreamElementsObsSceneManager.hpp
+++ b/streamelements/StreamElementsObsSceneManager.hpp
@@ -124,6 +124,10 @@ public:
 						 CefRefPtr<CefValue> &output);
 
 protected:
+	void DeserializeAuxiliaryObsSceneItemProperties(
+		obs_sceneitem_t *sceneitem, CefRefPtr<CefDictionaryValue> d);
+
+protected:
 	QMainWindow *mainWindow() { return m_parent; }
 
 	void ObsAddSourceInternal(obs_source_t *parentScene,
@@ -142,6 +146,9 @@ protected:
 	std::string ObsGetUniqueSceneName(std::string name);
 
 	std::string ObsGetUniqueSceneCollectionName(std::string name);
+
+	std::string ObsSetUniqueSourceName(obs_source_t *source,
+					   std::string name);
 
 private:
 	static void handle_obs_frontend_event(enum obs_frontend_event event,

--- a/streamelements/StreamElementsPleaseWaitWindow.cpp
+++ b/streamelements/StreamElementsPleaseWaitWindow.cpp
@@ -1,0 +1,61 @@
+#include "StreamElementsPleaseWaitWindow.hpp"
+#include "ui_streamelementspleasewaitwindow.h"
+
+#include "StreamElementsUtils.hpp"
+
+#include <QMainWindow>
+
+#include <obs-frontend-api.h>
+#include <util/threading.h>
+
+#include <mutex>
+
+StreamElementsPleaseWaitWindow *StreamElementsPleaseWaitWindow::s_instance = nullptr;
+
+StreamElementsPleaseWaitWindow::StreamElementsPleaseWaitWindow(QWidget *parent) : QDialog(parent),
+    ui(new Ui::StreamElementsPleaseWaitWindow)
+{
+    ui->setupUi(this);
+
+    // Remove title bar
+    setWindowFlags(Qt::CustomizeWindowHint);
+    setWindowModality(Qt::ApplicationModal);
+    setModal(true);
+}
+
+StreamElementsPleaseWaitWindow::~StreamElementsPleaseWaitWindow()
+{
+    delete ui;
+}
+
+StreamElementsPleaseWaitWindow* StreamElementsPleaseWaitWindow::GetInstance()
+{
+	static std::mutex s_mutex;
+
+	if (!s_instance) {
+		std::lock_guard<std::mutex> guard(s_mutex);
+
+		if (!s_instance) {
+			QMainWindow *mainWindow =
+				(QMainWindow *)obs_frontend_get_main_window();
+
+			s_instance = new StreamElementsPleaseWaitWindow(mainWindow);
+		}
+	}
+
+	return s_instance;
+}
+
+void StreamElementsPleaseWaitWindow::Show()
+{
+	if (os_atomic_inc_long(&m_showCount) == 1) {
+		QtPostTask([this]() { this->open(); });
+	}
+}
+
+void StreamElementsPleaseWaitWindow::Hide()
+{
+	if (os_atomic_dec_long(&m_showCount) == 0) {
+		QtPostTask([this]() { this->hide(); });
+	}
+}

--- a/streamelements/StreamElementsPleaseWaitWindow.hpp
+++ b/streamelements/StreamElementsPleaseWaitWindow.hpp
@@ -1,0 +1,35 @@
+#ifndef STREAMELEMENTSPLEASEWAITWINDOW_H
+#define STREAMELEMENTSPLEASEWAITWINDOW_H
+
+#include <QWidget>
+#include <QDialog>
+
+#include <mutex>
+
+namespace Ui {
+class StreamElementsPleaseWaitWindow;
+}
+
+class StreamElementsPleaseWaitWindow : public QDialog {
+    Q_OBJECT
+
+public:
+	static StreamElementsPleaseWaitWindow *GetInstance();
+
+	void Show();
+	void Hide();
+
+protected:
+	explicit StreamElementsPleaseWaitWindow(QWidget *parent = 0);
+	~StreamElementsPleaseWaitWindow();
+
+private:
+	Ui::StreamElementsPleaseWaitWindow *ui;
+
+	long m_showCount = 0;
+
+private:
+	static StreamElementsPleaseWaitWindow *s_instance;
+};
+
+#endif // STREAMELEMENTSPLEASEWAITWINDOW_H

--- a/streamelements/StreamElementsPleaseWaitWindow.ui
+++ b/streamelements/StreamElementsPleaseWaitWindow.ui
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StreamElementsPleaseWaitWindow</class>
+ <widget class="QDialog" name="StreamElementsPleaseWaitWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>415</width>
+    <height>143</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>415</width>
+     <height>143</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>200</width>
+     <height>100</height>
+    </size>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>19</pointsize>
+     <weight>50</weight>
+     <bold>false</bold>
+     <kerning>true</kerning>
+    </font>
+   </property>
+   <property name="cursor">
+    <cursorShape>WaitCursor</cursorShape>
+   </property>
+   <property name="contextMenuPolicy">
+    <enum>Qt::NoContextMenu</enum>
+   </property>
+   <property name="text">
+    <string>Please wait...</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/streamelements/StreamElementsSceneItemsMonitor.cpp
+++ b/streamelements/StreamElementsSceneItemsMonitor.cpp
@@ -176,8 +176,7 @@ static bool HandleDefaultActionRequest(obs_sceneitem_t *scene_item,
 				if (!scene_item)
 					return;
 
-				monitor
-					->InvokeCurrentSceneItemDefaultAction(
+				monitor->InvokeCurrentSceneItemDefaultContextMenu(
 						scene_item);
 			};
 

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -188,6 +188,7 @@ double GetObsGlobalFramesPerSecond();
 /* ========================================================= */
 
 void AdviseHostUserInterfaceStateChanged();
+void AdviseHostHotkeyBindingsChanged();
 
 /* ========================================================= */
 

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 34
+#define HOST_API_VERSION_MINOR 35
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
Add API methods:

* batchInvokeSeries

Throttle events:

* hostHotkeyBindingsChanged

Add "please wait" blocked UI state to:

* beginDeferSaveTransaction
* completeDeferSaveTransaction

Support setting `order` & auxiliary/default/context actions for:

* addCurrentSceneItemObsNativeSource
* addSceneItemObsNativeSource
* addCurrentSceneItemGroup
* addSceneItemGroup
* setCurrentSceneItemPropertiesById
* setSceneItemPropertiesById
* addSceneItemVideoCaptureSource
* addCurrentSceneItemVideoCaptureSource
* addSceneItemGameCaptureSource
* addCurrentSceneItemGameCaptureSource
* addSceneItemBrowserSource
* addCurrentSceneItemBrowserSource

Infrastructure:

* Remove redundant calls to QApplication::processEvents() where
  possible.