### PR TITLE
obs-browser: macos: resolve crashes when removing central widget

### DIFF
--- a/streamelements/StreamElementsBrowserWidget.cpp
+++ b/streamelements/StreamElementsBrowserWidget.cpp
@@ -53,7 +53,6 @@ StreamElementsBrowserWidget::StreamElementsBrowserWidget(
 {
 	// Create native window
 	setAttribute(Qt::WA_NativeWindow);
-	// setAttribute(Qt::WA_QuitOnClose, false);
 
 	// This influences docking widget width/height
 	//setMinimumWidth(200);
@@ -88,7 +87,7 @@ std::string StreamElementsBrowserWidget::GetInitialPageURLInternal()
 	htmlString = std::regex_replace(htmlString, std::regex("\\$\\{URL\\}"),
 					m_url);
 	std::string base64uri =
-		"data:text/html;base64," +
+		"data:text/html;base64," +	
 		CefBase64Encode(htmlString.c_str(), htmlString.size())
 			.ToString();
 
@@ -101,6 +100,8 @@ void StreamElementsBrowserWidget::InitBrowserAsyncInternal()
 		return;
 	}
 
+	blog(LOG_INFO, "InitBrowserAsyncInternal %s", m_url.c_str());
+
 	m_window_handle = (cef_window_handle_t)winId();
 
 	CefUIThreadExecute(
@@ -108,9 +109,11 @@ void StreamElementsBrowserWidget::InitBrowserAsyncInternal()
 			std::lock_guard<std::mutex> guard(
 				m_create_destroy_mutex);
 
+	blog(LOG_INFO, "InitBrowserAsyncInternal - CEF UI 1: %s", m_url.c_str());
 			if (!!m_cef_browser.get()) {
 				return;
 			}
+	blog(LOG_INFO, "InitBrowserAsyncInternal - CEF UI 2: %s", m_url.c_str());
 
 			StreamElementsBrowserWidget *self = this;
 
@@ -187,6 +190,7 @@ void StreamElementsBrowserWidget::InitBrowserAsyncInternal()
 						nullptr);
 			}
 
+	blog(LOG_INFO, "InitBrowserAsyncInternal - CEF UI 3: %s", m_url.c_str());
 			m_cef_browser = CefBrowserHost::CreateBrowserSync(
 				windowInfo, cefClient,
 				GetInitialPageURLInternal(), cefBrowserSettings,
@@ -195,7 +199,9 @@ void StreamElementsBrowserWidget::InitBrowserAsyncInternal()
 #endif
 				cefRequestContext);
 
+	blog(LOG_INFO, "InitBrowserAsyncInternal - CEF UI 4: %s", m_url.c_str());
 			UpdateBrowserSize();
+	blog(LOG_INFO, "InitBrowserAsyncInternal - CEF UI 5: %s", m_url.c_str());
 		},
 		true);
 }

--- a/streamelements/StreamElementsBrowserWidget.cpp
+++ b/streamelements/StreamElementsBrowserWidget.cpp
@@ -100,8 +100,6 @@ void StreamElementsBrowserWidget::InitBrowserAsyncInternal()
 		return;
 	}
 
-	blog(LOG_INFO, "InitBrowserAsyncInternal %s", m_url.c_str());
-
 	m_window_handle = (cef_window_handle_t)winId();
 
 	CefUIThreadExecute(
@@ -109,11 +107,9 @@ void StreamElementsBrowserWidget::InitBrowserAsyncInternal()
 			std::lock_guard<std::mutex> guard(
 				m_create_destroy_mutex);
 
-	blog(LOG_INFO, "InitBrowserAsyncInternal - CEF UI 1: %s", m_url.c_str());
 			if (!!m_cef_browser.get()) {
 				return;
 			}
-	blog(LOG_INFO, "InitBrowserAsyncInternal - CEF UI 2: %s", m_url.c_str());
 
 			StreamElementsBrowserWidget *self = this;
 
@@ -190,7 +186,6 @@ void StreamElementsBrowserWidget::InitBrowserAsyncInternal()
 						nullptr);
 			}
 
-	blog(LOG_INFO, "InitBrowserAsyncInternal - CEF UI 3: %s", m_url.c_str());
 			m_cef_browser = CefBrowserHost::CreateBrowserSync(
 				windowInfo, cefClient,
 				GetInitialPageURLInternal(), cefBrowserSettings,
@@ -199,9 +194,7 @@ void StreamElementsBrowserWidget::InitBrowserAsyncInternal()
 #endif
 				cefRequestContext);
 
-	blog(LOG_INFO, "InitBrowserAsyncInternal - CEF UI 4: %s", m_url.c_str());
 			UpdateBrowserSize();
-	blog(LOG_INFO, "InitBrowserAsyncInternal - CEF UI 5: %s", m_url.c_str());
 		},
 		true);
 }

--- a/streamelements/StreamElementsBrowserWidget.hpp
+++ b/streamelements/StreamElementsBrowserWidget.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "StreamElementsUtils.hpp"
+#include "StreamElementsBrowserWidget.hpp"
 
 #include <QWidget>
 #include <QHideEvent>
@@ -336,6 +337,7 @@ protected:
 				0L);
 #endif
 
+			//m_cef_browser->GetHost()->WasHidden(true);
 			m_cef_browser->GetHost()->CloseBrowser(true);
 			m_cef_browser = NULL;
 		}

--- a/streamelements/StreamElementsBrowserWidget.hpp
+++ b/streamelements/StreamElementsBrowserWidget.hpp
@@ -326,7 +326,7 @@ protected:
 	{
 		std::lock_guard<std::mutex> guard(m_create_destroy_mutex);
 
-		if (m_cef_browser.get() != NULL) {
+		if (!!m_cef_browser.get()) {
 			HideBrowser();
 
 #ifdef WIN32
@@ -335,10 +335,12 @@ protected:
 			::SetParent(
 				m_cef_browser->GetHost()->GetWindowHandle(),
 				0L);
-#endif
 
-			//m_cef_browser->GetHost()->WasHidden(true);
+			// Calling this on MacOS causes quit signal to propagate to the main window
+			// and quit the app
 			m_cef_browser->GetHost()->CloseBrowser(true);
+#endif
+			
 			m_cef_browser = NULL;
 		}
 	}

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -230,6 +230,17 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 	case OBS_FRONTEND_EVENT_EXIT:
 		name = "hostExit";
 		break;
+	case OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED:
+		if (StreamElementsGlobalStateManager::GetInstance()
+			    ->GetWidgetManager()
+			    ->HasCentralBrowserWidget()) {
+			// Due to the way we are now managing the central widget
+			// (constrained by MacOS support), we must make sure that
+			// the Studio Mode is disabled while the central widget
+			// is visible, otherwise it will take up its space.
+			obs_frontend_set_preview_program_mode(false);
+		}
+		break;
 	default:
 		return;
 	}

--- a/streamelements/StreamElementsWidgetManager.cpp
+++ b/streamelements/StreamElementsWidgetManager.cpp
@@ -29,7 +29,8 @@ StreamElementsWidgetManager::~StreamElementsWidgetManager() {}
 // QApplication::sendPostedEvents().
 // Then we reset the new central widget minimum size to 0x0.
 //
-void StreamElementsWidgetManager::PushCentralWidget(QWidget *widget)
+void StreamElementsWidgetManager::PushCentralWidget(
+	QWidget *widget)
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
@@ -74,8 +75,9 @@ bool StreamElementsWidgetManager::DestroyCurrentCentralWidget()
 	QWidget* preview = m_parent->centralWidget()->findChild<QWidget*>("preview");
 
 	m_currentCentralWidget->setVisible(false);
-	layout->removeWidget(m_currentCentralWidget);
-	m_currentCentralWidget->deleteLater(); 
+	int index = layout->indexOf(m_currentCentralWidget);
+	layout->takeAt(index);
+	m_currentCentralWidget->deleteLater();
 	m_currentCentralWidget = nullptr;
 
 	preview->setVisible(true);

--- a/streamelements/StreamElementsWidgetManager.cpp
+++ b/streamelements/StreamElementsWidgetManager.cpp
@@ -75,13 +75,13 @@ bool StreamElementsWidgetManager::DestroyCurrentCentralWidget()
 	QWidget* preview = m_parent->centralWidget()->findChild<QWidget*>("preview");
 
 	m_currentCentralWidget->setVisible(false);
-	int index = layout->indexOf(m_currentCentralWidget);
-	layout->takeAt(index);
+
+	m_currentCentralWidget->parentWidget()->layout()->removeWidget(m_currentCentralWidget);
 	m_currentCentralWidget->deleteLater();
-	m_currentCentralWidget = nullptr;
 
 	preview->setVisible(true);
 
+	m_currentCentralWidget = nullptr;
 	/*
 	if (!!m_nativeCentralWidget) {
 		SaveDockWidgetsGeometry();

--- a/streamelements/StreamElementsWidgetManager.cpp
+++ b/streamelements/StreamElementsWidgetManager.cpp
@@ -8,7 +8,7 @@
 #include <QApplication>
 
 StreamElementsWidgetManager::StreamElementsWidgetManager(QMainWindow *parent)
-	: m_parent(parent), m_nativeCentralWidget(nullptr)
+	: m_parent(parent)//, m_nativeCentralWidget(nullptr)
 {
 	assert(parent);
 }
@@ -35,9 +35,13 @@ void StreamElementsWidgetManager::PushCentralWidget(QWidget *widget)
 
 	if (m_currentCentralWidget) return;
 
+	// This will be additionally enforced by OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED event
+	// handler in handle_obs_frontend_event defined in StreamElementsGlobalStateManager.cpp
 	obs_frontend_set_preview_program_mode(false);
 
+	// Make sure changes take effect by draining the event queue
 	QApplication::sendPostedEvents();
+
 	//QSize prevSize = mainWindow()->centralWidget()->size();
 
 	//widget->setMinimumSize(prevSize);
@@ -75,8 +79,7 @@ bool StreamElementsWidgetManager::DestroyCurrentCentralWidget()
 
 	preview->setVisible(true);
 
-	return false;
-
+	/*
 	if (!!m_nativeCentralWidget) {
 		SaveDockWidgetsGeometry();
 
@@ -96,6 +99,7 @@ bool StreamElementsWidgetManager::DestroyCurrentCentralWidget()
 
 		RestoreDockWidgetsGeometry();
 	}
+	*/
 
 	// No more widgets
 	return false;
@@ -105,7 +109,8 @@ bool StreamElementsWidgetManager::HasCentralWidget()
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-	return !!m_nativeCentralWidget;
+	return !!m_currentCentralWidget;
+	//return !!m_nativeCentralWidget;
 }
 
 void StreamElementsWidgetManager::OnObsExit()

--- a/streamelements/StreamElementsWidgetManager.cpp
+++ b/streamelements/StreamElementsWidgetManager.cpp
@@ -53,26 +53,38 @@ bool StreamElementsWidgetManager::DestroyCurrentCentralWidget()
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
 	if (!!m_nativeCentralWidget) {
+		blog(LOG_INFO, "DestroyCurrentCentralWidget: cp1");
 		SaveDockWidgetsGeometry();
 
+		blog(LOG_INFO, "DestroyCurrentCentralWidget: cp2");
 		QApplication::sendPostedEvents();
+		blog(LOG_INFO, "DestroyCurrentCentralWidget: cp3");
 		QSize currSize = mainWindow()->centralWidget()->size();
 
+		blog(LOG_INFO, "DestroyCurrentCentralWidget: cp4");
 		m_parent->setCentralWidget(m_nativeCentralWidget);
 
+		blog(LOG_INFO, "DestroyCurrentCentralWidget: cp5");
 		m_nativeCentralWidget = nullptr;
 
+		blog(LOG_INFO, "DestroyCurrentCentralWidget: cp6");
 		mainWindow()->centralWidget()->setMinimumSize(currSize);
 
+		blog(LOG_INFO, "DestroyCurrentCentralWidget: cp7");
 		// Drain event queue
 		QApplication::sendPostedEvents();
 
+		blog(LOG_INFO, "DestroyCurrentCentralWidget: cp8");
 		mainWindow()->centralWidget()->setMinimumSize(0, 0);
 
+		blog(LOG_INFO, "DestroyCurrentCentralWidget: cp9");
 		RestoreDockWidgetsGeometry();
+
+		blog(LOG_INFO, "DestroyCurrentCentralWidget: cp10");
 	}
 
-	return nullptr;
+	// No more widgets
+	return false;
 }
 
 bool StreamElementsWidgetManager::HasCentralWidget()

--- a/streamelements/StreamElementsWidgetManager.cpp
+++ b/streamelements/StreamElementsWidgetManager.cpp
@@ -75,6 +75,7 @@ bool StreamElementsWidgetManager::DestroyCurrentCentralWidget()
 
 	m_currentCentralWidget->setVisible(false);
 	layout->removeWidget(m_currentCentralWidget);
+	m_currentCentralWidget->deleteLater(); 
 	m_currentCentralWidget = nullptr;
 
 	preview->setVisible(true);

--- a/streamelements/StreamElementsWidgetManager.hpp
+++ b/streamelements/StreamElementsWidgetManager.hpp
@@ -94,7 +94,7 @@ protected:
 
 private:
 	QMainWindow* m_parent;
-	QWidget* m_nativeCentralWidget;
+	//QWidget* m_nativeCentralWidget;
 	QWidget* m_currentCentralWidget = nullptr;
 
 	std::map<std::string, QDockWidget*> m_dockWidgets;

--- a/streamelements/StreamElementsWidgetManager.hpp
+++ b/streamelements/StreamElementsWidgetManager.hpp
@@ -95,6 +95,7 @@ protected:
 private:
 	QMainWindow* m_parent;
 	QWidget* m_nativeCentralWidget;
+	QWidget* m_currentCentralWidget = nullptr;
 
 	std::map<std::string, QDockWidget*> m_dockWidgets;
 	std::map<std::string, Qt::DockWidgetArea> m_dockWidgetAreas;


### PR DESCRIPTION
1. Avoid calling CefBrowserHost::CloseBrowser(true) on MacOS: it sends a quit message to the main application window
2. Instead of replacing central widget completely, add & remove our browser widget to/from the preview layout
