### PR TITLE
obs-browser: clean up redundant code changes

### DIFF
--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -230,7 +230,7 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 	case OBS_FRONTEND_EVENT_EXIT:
 		name = "hostExit";
 		break;
-	case OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED:
+	/*case OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED:
 		if (StreamElementsGlobalStateManager::GetInstance()
 			    ->GetWidgetManager()
 			    ->HasCentralBrowserWidget()) {
@@ -240,7 +240,8 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 			// is visible, otherwise it will take up its space.
 			obs_frontend_set_preview_program_mode(false);
 		}
-		break;
+		return;
+	*/
 	default:
 		return;
 	}

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -325,16 +325,6 @@ void StreamElementsGlobalStateManager::Initialize(QMainWindow *obs_main_window)
 	context.obs_main_window = obs_main_window;
 
 	QtExecSync([](void *data) -> void {
-#ifdef __APPLE__
-        {
-            // Set application icon from app bundle's Resources/obs.icns
-            const char* iconFilePath = "../Resources/obs.icns";
-            if (os_file_exists(iconFilePath)) {
-                qApp->setWindowIcon(QIcon(iconFilePath));
-            }
-        }
-#endif
-        
 			local_context *context = (local_context *)data;
 
 			// http://doc.qt.io/qt-5/qmainwindow.html#DockOption-enum

--- a/streamelements/StreamElementsWidgetManager.hpp
+++ b/streamelements/StreamElementsWidgetManager.hpp
@@ -94,8 +94,8 @@ protected:
 
 private:
 	QMainWindow* m_parent;
-	//QWidget* m_nativeCentralWidget;
-	QWidget* m_currentCentralWidget = nullptr;
+	QWidget* m_nativeCentralWidget = nullptr;
+	//QWidget* m_currentCentralWidget = nullptr;
 
 	std::map<std::string, QDockWidget*> m_dockWidgets;
 	std::map<std::string, Qt::DockWidgetArea> m_dockWidgetAreas;


### PR DESCRIPTION
- roll back changes to how the central widget is managed
- remove attempt to change runtime app icon
