### PR TITLE
MacOS: Enable context menu on browser text fields

### DIFF
--- a/cef-headers.hpp
+++ b/cef-headers.hpp
@@ -37,6 +37,7 @@
 #include <include/cef_render_process_handler.h>
 #include <include/cef_request_context_handler.h>
 #include <include/cef_jsdialog_handler.h>
+#include <include/cef_focus_handler.h>
 
 #if CHROME_VERSION_BUILD < 3770
 #define ENABLE_DECRYPT_COOKIES 1

--- a/streamelements/StreamElementsBrowserWidget.hpp
+++ b/streamelements/StreamElementsBrowserWidget.hpp
@@ -207,6 +207,20 @@ protected:
 		}
 	}
 
+	virtual void focusInEvent(QFocusEvent* event) override
+	{
+		QWidget::focusInEvent(event);
+
+		blog(LOG_INFO, "QWidget::focusInEvent: reason %d: %s", event->reason(), m_url.c_str());
+	}
+
+	virtual void focusOutEvent(QFocusEvent* event) override
+	{
+		QWidget::focusOutEvent(event);
+
+		blog(LOG_INFO, "QWidget::focusOutEvent: %s", m_url.c_str());
+	}
+
 private:
 	void UpdateBrowserSize()
 	{
@@ -382,6 +396,14 @@ private:
 				StreamElementsBrowserWidget* widget = (StreamElementsBrowserWidget*)data;
 
 				widget->emitBrowserStateChanged();
+			}, m_widget);
+		}
+
+		virtual void OnGotFocus(CefRefPtr<CefBrowser>) override {
+			QtPostTask([](void* data) {
+				StreamElementsBrowserWidget* widget = (StreamElementsBrowserWidget*)data;
+
+				widget->setFocus();
 			}, m_widget);
 		}
 

--- a/streamelements/StreamElementsCefClient.cpp
+++ b/streamelements/StreamElementsCefClient.cpp
@@ -634,3 +634,27 @@ bool StreamElementsCefClient::OnJSDialog(
 		return false;
 	}
 }
+
+/* CefFocusHandler */
+
+void StreamElementsCefClient::OnGotFocus(CefRefPtr<CefBrowser> browser)
+{
+	blog(LOG_INFO, "OnGotFocus");
+
+	if (m_eventHandler) {
+		m_eventHandler->OnGotFocus(browser);
+	}
+}
+
+bool StreamElementsCefClient::OnSetFocus(CefRefPtr<CefBrowser> browser, CefFocusHandler::FocusSource source)
+{
+	blog(LOG_INFO, "OnSetFocus: source: %s", source == FOCUS_SOURCE_NAVIGATION ? "navigation" : (source == FOCUS_SOURCE_SYSTEM ? "system" : "other"));
+
+	// Allow focus to be set
+	return false;
+}
+
+void StreamElementsCefClient::OnTakeFocus(CefRefPtr<CefBrowser> browser, bool next)
+{
+	blog(LOG_INFO, "OnTakeFocus: next: %s", next ? "true" : "false");
+}

--- a/streamelements/StreamElementsCefClient.hpp
+++ b/streamelements/StreamElementsCefClient.hpp
@@ -27,6 +27,9 @@ public:
 		UNREFERENCED_PARAMETER(canGoForward);
 	}
 
+	virtual void OnGotFocus(CefRefPtr<CefBrowser>) {
+	}
+
 public:
 	IMPLEMENT_REFCOUNTING(StreamElementsCefClientEventHandler);
 };
@@ -40,6 +43,7 @@ class StreamElementsCefClient : public CefClient,
 				public CefRequestHandler,
 				public CefRenderHandler,
 				public CefJSDialogHandler,
+				public CefFocusHandler,
 #if CHROME_VERSION_BUILD >= 3770
 				public CefResourceRequestHandler,
 #endif
@@ -143,6 +147,10 @@ public:
 		return this;
 	}
 	virtual CefRefPtr<CefRenderHandler> GetRenderHandler() override
+	{
+		return this;
+	}
+	virtual CefRefPtr<CefFocusHandler> GetFocusHandler() override
 	{
 		return this;
 	}
@@ -320,8 +328,10 @@ public:
 					 CefRefPtr<CefContextMenuParams> params,
 					 CefRefPtr<CefMenuModel> model) override
 	{
+#ifdef WIN32
 		// Remove all context menu contributions
 		model->Clear();
+#endif
 	}
 
 	/* CefLoadHandler */
@@ -394,6 +404,9 @@ public:
 		CefRefPtr<CefBrowser> browser, CefRect &rect) override
 	{
 		rect.Set(0, 0, 1920, 1080);
+#if CHROME_VERSION_BUILD < 3578
+		return true;
+#endif
 	}
 
 	virtual void OnPaint(CefRefPtr<CefBrowser> browser,
@@ -410,7 +423,12 @@ public:
 				const CefString &message_text,
 				const CefString &default_prompt_text,
 				CefRefPtr<CefJSDialogCallback> callback,
-				bool &suppress_message);
+				bool &suppress_message) override;
+
+	/* CefFocusHandler */
+	virtual void OnGotFocus(CefRefPtr<CefBrowser> browser) override;
+	virtual bool OnSetFocus(CefRefPtr<CefBrowser> browser, CefFocusHandler::FocusSource source) override;
+	virtual void OnTakeFocus(CefRefPtr<CefBrowser> browser, bool next) override;
 
 #if EXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED
 	virtual void OnAcceleratedPaint(CefRefPtr<CefBrowser> browser,


### PR DESCRIPTION
This partially enables Copy & Paste for CEF browser widgets on MacOS.

This commit also contains boilerplate code for working around CEF's
missing calls to OnTakeFocus, which should indicate that focus was
lost by the CEF browser.

A more elaborate solution, including Edit menu elements could be based
upon this infrastructure.