### PR TITLE
Fix memory corruption during async API calls

### DIFF
--- a/streamelements/StreamElementsBrowserWidget.cpp
+++ b/streamelements/StreamElementsBrowserWidget.cpp
@@ -144,11 +144,11 @@ void StreamElementsBrowserWidget::InitBrowserAsyncInternal()
 			cefBrowserSettings.databases = STATE_ENABLED;
 			cefBrowserSettings.web_security = STATE_ENABLED;
 			cefBrowserSettings.webgl = STATE_ENABLED;
-			const int DEFAULT_FONT_SIZE = 12;
+			const int DEFAULT_FONT_SIZE = 16;
 			cefBrowserSettings.default_font_size = DEFAULT_FONT_SIZE;
 			cefBrowserSettings.default_fixed_font_size = DEFAULT_FONT_SIZE;
-			cefBrowserSettings.minimum_font_size = DEFAULT_FONT_SIZE;
-			cefBrowserSettings.minimum_logical_font_size = DEFAULT_FONT_SIZE;
+			//cefBrowserSettings.minimum_font_size = DEFAULT_FONT_SIZE;
+			//cefBrowserSettings.minimum_logical_font_size = DEFAULT_FONT_SIZE;
 
 			if (m_requestedApiMessageHandler == nullptr) {
 				m_requestedApiMessageHandler =


### PR DESCRIPTION
* Carry all external referenced objects in `batchInvokeSeries` inside
  `local_context` instead of referencing them directly

* Deallocate API entry point `local_context` only after
  `local_context::complete()` call was made