### PR TITLE
API 2.1: Support for output preview UI elements

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -350,8 +350,24 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandler(
 
 static std::recursive_mutex s_sync_api_call_mutex;
 
-#define API_HANDLER_BEGIN(name) RegisterIncomingApiCallHandler(name, [](StreamElementsApiMessageHandler*, CefRefPtr<CefProcessMessage> message, CefRefPtr<CefListValue> args, CefRefPtr<CefValue>& result, CefRefPtr<CefBrowser> browser, const long cefClientId, std::function<void()> complete_callback) { std::lock_guard<std::recursive_mutex> _api_sync_guard(s_sync_api_call_mutex);
-#define API_HANDLER_END()                    \
+#define API_HANDLER_BEGIN(name) \
+	RegisterIncomingApiCallHandler(name, []( \
+		StreamElementsApiMessageHandler*, \
+		CefRefPtr<CefProcessMessage> message, \
+		CefRefPtr<CefListValue> args, \
+		CefRefPtr<CefValue>& result, \
+		CefRefPtr<CefBrowser> browser, \
+		const long cefClientId, \
+		std::function<void()> complete_callback) \
+		{ \
+			(void)message; \
+			(void)args; \
+			(void)result; \
+			(void)browser; \
+			(void)cefClientId; \
+			(void)complete_callback; \
+			std::lock_guard<std::recursive_mutex> _api_sync_guard(s_sync_api_call_mutex);
+#define API_HANDLER_END() \
 	complete_callback(); \
 	});
 
@@ -2220,6 +2236,60 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		result->SetBool(StreamElementsGlobalStateManager::GetInstance()
 					->GetMenuManager()
 					->GetShowBuiltInMenuItems());
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("showOutputPreviewTitleBar");
+	{
+		if (args->GetSize()) {
+			result->SetBool(
+				StreamElementsGlobalStateManager::GetInstance()
+					->GetNativeOBSControlsManager()
+					->DeserializePreviewTitleBar(
+						args->GetValue(0)));
+
+			StreamElementsGlobalStateManager::GetInstance()
+				->PersistState();
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("hideOutputPreviewTitleBar");
+	{
+		StreamElementsGlobalStateManager::GetInstance()
+			->GetNativeOBSControlsManager()
+			->HidePreviewTitleBar();
+
+		result->SetBool(true);
+
+		StreamElementsGlobalStateManager::GetInstance()->PersistState();
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("showOutputPreviewFrame");
+	{
+		if (args->GetSize()) {
+			result->SetBool(
+				StreamElementsGlobalStateManager::GetInstance()
+					->GetNativeOBSControlsManager()
+					->DeserializePreviewFrame(
+						args->GetValue(0)));
+
+			StreamElementsGlobalStateManager::GetInstance()
+				->PersistState();
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("hideOutputPreviewFrame");
+	{
+		StreamElementsGlobalStateManager::GetInstance()
+			->GetNativeOBSControlsManager()
+			->HidePreviewFrame();
+
+		result->SetBool(true);
+
+		StreamElementsGlobalStateManager::GetInstance()->PersistState();
 	}
 	API_HANDLER_END();
 

--- a/streamelements/StreamElementsBrowserDialog.cpp
+++ b/streamelements/StreamElementsBrowserDialog.cpp
@@ -7,8 +7,27 @@
 
 static std::recursive_mutex s_sync_api_call_mutex;
 
-#define API_HANDLER_BEGIN(name) RegisterIncomingApiCallHandler(name, [](StreamElementsApiMessageHandler* self, CefRefPtr<CefProcessMessage> message, CefRefPtr<CefListValue> args, CefRefPtr<CefValue>& result, CefRefPtr<CefBrowser> browser, const long cefClientId, std::function<void()> complete_callback) { std::lock_guard<std::recursive_mutex> _api_sync_guard(s_sync_api_call_mutex);
-#define API_HANDLER_END() complete_callback(); });
+#define API_HANDLER_BEGIN(name)                          \
+	RegisterIncomingApiCallHandler(name, []( \
+		StreamElementsApiMessageHandler* self, \
+		CefRefPtr<CefProcessMessage> message, \
+		CefRefPtr<CefListValue> args, \
+		CefRefPtr<CefValue>& result, \
+		CefRefPtr<CefBrowser> browser, \
+		const long cefClientId, \
+		std::function<void()> complete_callback) \
+		{ \
+			(void)self; \
+			(void)message; \
+			(void)args; \
+			(void)result; \
+			(void)browser; \
+			(void)cefClientId; \
+			(void)complete_callback; \
+			std::lock_guard<std::recursive_mutex> _api_sync_guard(s_sync_api_call_mutex);
+#define API_HANDLER_END()    \
+	complete_callback(); \
+	});
 
 class StreamElementsDialogApiMessageHandler : public StreamElementsApiMessageHandler
 {

--- a/streamelements/StreamElementsBrowserSourceApiMessageHandler.cpp
+++ b/streamelements/StreamElementsBrowserSourceApiMessageHandler.cpp
@@ -5,8 +5,26 @@
 
 static std::recursive_mutex s_sync_api_call_mutex;
 
-#define API_HANDLER_BEGIN(name) RegisterIncomingApiCallHandler(name, [](StreamElementsApiMessageHandler*, CefRefPtr<CefProcessMessage> message, CefRefPtr<CefListValue> args, CefRefPtr<CefValue>& result, CefRefPtr<CefBrowser> browser, const long cefClientId, std::function<void()> complete_callback) { std::lock_guard<std::recursive_mutex> _api_sync_guard(s_sync_api_call_mutex);
-#define API_HANDLER_END() complete_callback(); });
+#define API_HANDLER_BEGIN(name)                          \
+	RegisterIncomingApiCallHandler(name, []( \
+		StreamElementsApiMessageHandler*, \
+		CefRefPtr<CefProcessMessage> message, \
+		CefRefPtr<CefListValue> args, \
+		CefRefPtr<CefValue>& result, \
+		CefRefPtr<CefBrowser> browser, \
+		const long cefClientId, \
+		std::function<void()> complete_callback) \
+		{ \
+			(void)message; \
+			(void)args; \
+			(void)result; \
+			(void)browser; \
+			(void)cefClientId; \
+			(void)complete_callback; \
+			std::lock_guard<std::recursive_mutex> _api_sync_guard(s_sync_api_call_mutex);
+#define API_HANDLER_END()    \
+	complete_callback(); \
+	});
 
 StreamElementsBrowserSourceApiMessageHandler::StreamElementsBrowserSourceApiMessageHandler()
 {

--- a/streamelements/StreamElementsNativeOBSControlsManager.hpp
+++ b/streamelements/StreamElementsNativeOBSControlsManager.hpp
@@ -4,6 +4,9 @@
 #include <QPushButton>
 #include <QObject>
 #include <QTimer>
+#include <QFrame>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
 
 #include "obs.h"
 #include "obs-hotkey.h"
@@ -14,7 +17,9 @@
 
 #include "cef-headers.hpp"
 
-class StreamElementsNativeOBSControlsManager : QObject
+#include "StreamElementsBrowserWidget.hpp"
+
+class StreamElementsNativeOBSControlsManager : public QObject
 {
 	Q_OBJECT
 
@@ -44,6 +49,15 @@ public:
 
 	void AdviseRequestStartStreamingAccepted();
 	void AdviseRequestStartStreamingRejected();
+
+	bool DeserializePreviewFrame(CefRefPtr<CefValue> input);
+	void SerializePreviewFrame(CefRefPtr<CefValue>& output);
+	void HidePreviewFrame();
+	bool DeserializePreviewTitleBar(CefRefPtr<CefValue> input);
+	void SerializePreviewTitleBar(CefRefPtr<CefValue>& output);
+	void HidePreviewTitleBar();
+
+	void Reset();
 
 private:
 	void SetStreamingInitialState();
@@ -77,6 +91,7 @@ private:
 	static void hotkey_routing_func(void* data, obs_hotkey_id id, bool pressed);
 
 private:
+	QWidget *m_nativeCentralWidget = nullptr;
 	QMainWindow* m_mainWindow = nullptr;
 	QPushButton* m_startStopStreamingButton = nullptr;
 	QPushButton* m_nativeStartStopStreamingButton = nullptr;
@@ -85,4 +100,19 @@ private:
 	int m_startStreamingRequestAcknowledgeTimeoutSeconds = 5;
 	QTimer* m_timeoutTimer = nullptr;
 	std::recursive_mutex m_timeoutTimerMutex;
+
+	QFrame *m_previewFrame = nullptr;
+	QVBoxLayout *m_previewFrameLayout = nullptr;
+	QLayout *m_nativePreviewLayout = nullptr;
+	QLayout *m_nativePreviewLayoutParent = nullptr;
+	QWidget *m_nativePreviewWidget = nullptr;
+	bool m_previewFrameVisible = false;
+	CefRefPtr<CefDictionaryValue> m_previewFrameSettings =
+		CefDictionaryValue::Create();
+
+	QWidget *m_previewTitleContainer = nullptr;
+	QHBoxLayout *m_previewTitleLayout = nullptr;
+	StreamElementsBrowserWidget *m_previewTitleBrowser = nullptr;
+	CefRefPtr<CefDictionaryValue> m_previewTitleSettings =
+		CefDictionaryValue::Create();
 };

--- a/streamelements/StreamElementsPreviewManager.cpp
+++ b/streamelements/StreamElementsPreviewManager.cpp
@@ -29,8 +29,6 @@ public:
 	{
 		QWidget *centralWidget = m_mainWindow->centralWidget();
 
-		std::string objectName = o->objectName().toStdString();
-
 		switch (e->type()) {
 		case QEvent::MouseButtonDblClick:
 			if (QApplication::keyboardModifiers() ==

--- a/streamelements/StreamElementsScenesListWidgetManager.cpp
+++ b/streamelements/StreamElementsScenesListWidgetManager.cpp
@@ -681,6 +681,19 @@ void StreamElementsScenesListWidgetManager::UpdateScenesToolbar()
 				QSizePolicy::Minimum);
 
 	m_scenesToolBar->addWidget(widget);
+
+	QMainWindow *mainWindow = (QMainWindow *)obs_frontend_get_main_window();
+
+	QDockWidget *scenesDock =
+		(QDockWidget *)mainWindow->findChild<QDockWidget *>(
+			"scenesDock");
+
+	if (list->GetSize()) {
+		scenesDock->setMinimumWidth(
+			m_scenesToolBar->sizeHint().width());
+	} else {
+		scenesDock->setMinimumWidth(0);
+	}
 }
 
 void StreamElementsScenesListWidgetManager::UpdateWidgets()

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -2304,7 +2304,7 @@ public:
 
 		setStyleSheet("background: none; padding: 0;");
 
-		setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Minimum);
+		setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 
 		CefRefPtr<StreamElementsRemoteIconLoader> loaderCopy = loader;
 
@@ -2315,11 +2315,21 @@ public:
 		});
 	}
 
-	virtual QSize minimumSizeHint() const override { return QSize(16, 16); }
+	virtual QSize minimumSizeHint() const override { return sizeHint(); }
 	virtual QSize sizeHint() const override
 	{
 		if (text().size()) {
-			return QPushButton::sizeHint();
+			QSize textSize = fontMetrics().size(
+				Qt::TextShowMnemonic, text());
+
+			QStyleOptionButton opt;
+			opt.initFrom(this);
+			opt.rect.setSize(textSize);
+
+			QSize size = style()->sizeFromContents(
+				QStyle::CT_PushButton, &opt, textSize, this);
+
+			return size;
 		} else {
 			return QSize(16, 16);
 		}
@@ -2600,8 +2610,10 @@ DeserializeAuxiliaryControlWidget(CefRefPtr<CefValue> input,
 	if (d->HasKey("color") && d->GetType("color") == VTYPE_STRING) {
 		styleSheet += "QPushButton { color: ";
 		styleSheet += d->GetString("color").ToString() + ";";
-		styleSheet += " }";
+		styleSheet += " } ";
 	}
+
+	styleSheet += "QPushButton { padding: 0; } ";
 
 	if (type == "container") {
 		if (!d->HasKey("items") || d->GetType("items") != VTYPE_LIST)
@@ -2662,12 +2674,15 @@ DeserializeAuxiliaryControlWidget(CefRefPtr<CefValue> input,
 			new QRemoteIconPushButton(iconUrl.c_str());
 
 		//control->setContentsMargins(0, 0, 0, 0);
-		control->setMinimumSize(16, 16);
-		control->setSizePolicy(QSizePolicy::Minimum,
-				       QSizePolicy::Minimum);
+		//control->setMinimumSize(16, 16);
+		//control->setSizePolicy(QSizePolicy::Minimum,
+		//		       QSizePolicy::Minimum);
 
 		if (d->HasKey("title") && d->GetType("title") == VTYPE_STRING) {
 			control->setText(
+				d->GetString("title").ToString().c_str());
+
+			control->setWindowIconText(
 				d->GetString("title").ToString().c_str());
 		}
 

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 0
+#define HOST_API_VERSION_MINOR 1
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
* Add output preview frame primitive
* Add output preview title bar primitive
* Remove API_HANDLER_BEGIN()-related compiler warnings
* Expand sources width so auxiliary actions are always visible
* Expand scenes width so auxiliary actions are always visible
* Add API support for changing source names' colors
* Remove padding from auxiliary action buttons

Add API methods:

* showOutputPreviewTitleBar
* hideOutputPreviewTitleBar
* showOutputPreviewFrame
* hideOutputPreviewFrame

Add data structures:

* FrameInfo

Add properties:

* SceneItemInfo.uiSettings.color
