### PR TITLE
Add Edit menu items for editable fields in browser

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -124,6 +124,24 @@ void BrowserApp::OnBeforeCommandLineProcessing(
 #endif
 }
 
+void BrowserApp::OnFocusedNodeChanged(CefRefPtr<CefBrowser> browser,
+				      CefRefPtr<CefFrame> frame,
+				      CefRefPtr<CefDOMNode> node)
+{
+	CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create(
+		"CefRenderProcessHandler::OnFocusedNodeChanged");
+
+	if (!!node.get() && node->IsEditable()) {
+		// Editable node
+		msg->GetArgumentList()->SetBool(0, true);
+	} else {
+		// Empty or non-editable node
+		msg->GetArgumentList()->SetBool(0, false);
+	}
+
+	SendBrowserProcessMessage(browser, PID_BROWSER, msg);
+}
+
 void BrowserApp::OnContextCreated(CefRefPtr<CefBrowser> browser,
 				  CefRefPtr<CefFrame>,
 				  CefRefPtr<CefV8Context> context)

--- a/browser-app.hpp
+++ b/browser-app.hpp
@@ -108,6 +108,9 @@ public:
 	virtual void OnContextCreated(CefRefPtr<CefBrowser> browser,
 				      CefRefPtr<CefFrame> frame,
 				      CefRefPtr<CefV8Context> context) override;
+	virtual void OnFocusedNodeChanged(CefRefPtr<CefBrowser> browser,
+					  CefRefPtr<CefFrame> frame,
+					  CefRefPtr<CefDOMNode> node) override;
 	virtual bool
 	OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 #if CHROME_VERSION_BUILD >= 3770

--- a/streamelements/StreamElementsBrowserWidget.cpp
+++ b/streamelements/StreamElementsBrowserWidget.cpp
@@ -14,17 +14,49 @@
 
 /* ========================================================================= */
 
+//
+// This block deals with a Win32-specific bug inherent to Qt 5.15.2:
+// when OBS loses input focus (app is deactivated), the currently
+// focused browser widget does not receive a KillFocus event, although
+// CEF does lose input focus.
+//
+// This makes any operations dependant on correctly tracking browser
+// widgets' focus state unstable.
+//
+// To mitigate this, on Windows, we subscribe to WH_CALLWNDPROC hook
+// for the application. Once the app receives a Windows event indicating
+// that the app was deactivated, we call `clearFocus()` on the currently
+// focused browser widget (if any).
+//
+// This results in the browser widget's focused state correctly reflecting
+// the focused state of the CEF browser it embeds.
+//
+// The Win32 hook approach is specific to Win32.
+//
+// On macOS focusIn() and focusOut() signals emitted by QWidget seem to
+// function properly.
+//
+
 #include <set>
 
-static std::recursive_mutex g_mainWindowFocusTrackerMutex;
-static std::set<QWidget *> g_mainWindowFocusTrackerWidgets;
+//
+// Registry of all browser widgets instances.
+//
+// StreamElementsBrowserWidget registers in it's ctor
+// and deregisters it it's dtor.
+//
+static std::recursive_mutex g_AppActiveTrackerMutex;
+static std::set<QWidget *> g_AppActiveTrackerWidgets;
 
-static void HandleMainWindowFocusTrackerWidgetUnfocus()
+//
+// Called by our hook procedure when app deactivates (loses focus).
+//
+static void HandleAppActiveTrackerWidgetUnfocus()
 {
-	std::lock_guard<decltype(g_mainWindowFocusTrackerMutex)> guard(
-		g_mainWindowFocusTrackerMutex);
+	std::lock_guard<decltype(g_AppActiveTrackerMutex)> guard(
+		g_AppActiveTrackerMutex);
 
-	for (auto &widget : g_mainWindowFocusTrackerWidgets) {
+	for (auto &widget : g_AppActiveTrackerWidgets) {
 		if (widget->hasFocus()) {
 			widget->clearFocus();
 		}
@@ -32,22 +64,27 @@ static void HandleMainWindowFocusTrackerWidgetUnfocus()
 }
 
 #ifdef _WIN32
-static HHOOK g_mainWindowFocusTrackerHook = NULL;
+// Our WH_CALLWNDPROC hook handle
+static HHOOK g_AppActiveTrackerHook = NULL;
 
-static LRESULT CALLBACK MainWindowFocusTrackerHook(_In_ int nCode,
-						   _In_ WPARAM wParam,
-						   _In_ LPARAM lParam)
+// Our WH_CALLWNDPROC hook procedure
+static LRESULT CALLBACK AppActiveTrackerHook(_In_ int nCode, _In_ WPARAM wParam,
+					     _In_ LPARAM lParam)
 {
 	CWPSTRUCT *msg = (CWPSTRUCT *)lParam;
 
 	if (msg->message == WM_ACTIVATEAPP) {
+		// Windows message indicating of app active/inactive state
+
 		if (!msg->wParam) {
+			// App deactivated (lost focus)
+
 			if (QThread::currentThread() == qApp->thread()) {
-				HandleMainWindowFocusTrackerWidgetUnfocus();
+				HandleAppActiveTrackerWidgetUnfocus();
 			} else {
 				// We're unlikely to reach here, but just in case
 				QtPostTask([]() {
-					HandleMainWindowFocusTrackerWidgetUnfocus();
+					HandleAppActiveTrackerWidgetUnfocus();
 				});
 			}
 		}
@@ -57,65 +94,79 @@ static LRESULT CALLBACK MainWindowFocusTrackerHook(_In_ int nCode,
 }
 #endif
 
-static void InitMainWindowFocusTracker()
+//
+// Subscribe to receive notifications re app becoming active/inactive
+//
+static void InitAppActiveTracker()
 {
 #ifdef _WIN32
-	if (g_mainWindowFocusTrackerHook)
+	if (g_AppActiveTrackerHook)
 		return;
 
-	g_mainWindowFocusTrackerHook =
-		SetWindowsHookExA(WH_CALLWNDPROC, MainWindowFocusTrackerHook,
+	g_AppActiveTrackerHook =
+		SetWindowsHookExA(WH_CALLWNDPROC, AppActiveTrackerHook,
 				  NULL, GetCurrentThreadId());
 
-	if (!g_mainWindowFocusTrackerHook) {
+	if (!g_AppActiveTrackerHook) {
 		blog(LOG_ERROR,
-		     "InitMainWindowFocusTracker: SetWindowsHookExA call failed");
+		     "InitAppActiveTracker: SetWindowsHookExA call failed");
 	} else {
 		blog(LOG_INFO,
-		     "InitMainWindowFocusTracker: SetWindowsHookExA succeeded");
+		     "InitAppActiveTracker: SetWindowsHookExA succeeded");
 	}
 #endif
 }
 
-static void ShutdownMainWindowFocusTracker()
+//
+// Unsubscribe from notifications re app becoming active/inactive
+//
+static void ShutdownAppActiveTracker()
 {
 #ifdef _WIN32
-	if (!g_mainWindowFocusTrackerHook)
+	if (!g_AppActiveTrackerHook)
 		return;
 
-	if (UnhookWindowsHookEx(g_mainWindowFocusTrackerHook)) {
-		g_mainWindowFocusTrackerHook = NULL;
+	if (UnhookWindowsHookEx(g_AppActiveTrackerHook)) {
+		g_AppActiveTrackerHook = NULL;
 
 		blog(LOG_INFO,
-		     "ShutdownMainWindowFocusTracker: UnhookWindowsHookEx succeeded");
+		     "ShutdownAppActiveTracker: UnhookWindowsHookEx succeeded");
 	} else {
 		blog(LOG_ERROR,
-		     "ShutdownMainWindowFocusTracker: UnhookWindowsHookEx call failed");
+		     "ShutdownAppActiveTracker: UnhookWindowsHookEx call failed");
 	}
 #endif
 }
 
-static void RegisterMainWindowFocusTrackerWidget(QWidget *widget)
+//
+// Register a QWidget interested in losing focus when app
+// becomes inactive.
+//
+static void RegisterAppActiveTrackerWidget(QWidget *widget)
 {
-	std::lock_guard<decltype(g_mainWindowFocusTrackerMutex)> guard(
-		g_mainWindowFocusTrackerMutex);
+	std::lock_guard<decltype(g_AppActiveTrackerMutex)> guard(
+		g_AppActiveTrackerMutex);
 
-	g_mainWindowFocusTrackerWidgets.emplace(widget);
+	g_AppActiveTrackerWidgets.emplace(widget);
 
-	if (g_mainWindowFocusTrackerWidgets.size() == 1) {
-		InitMainWindowFocusTracker();
+	if (g_AppActiveTrackerWidgets.size() == 1) {
+		InitAppActiveTracker();
 	}
 }
 
-static void UnRegisterMainWindowFocusTrackerWidget(QWidget *widget)
+//
+// Unregister a QWidget no longer interested in losing
+// focus when app becomes inactive.
+//
+static void UnregisterAppActiveTrackerWidget(QWidget *widget)
 {
-	std::lock_guard<decltype(g_mainWindowFocusTrackerMutex)> guard(
-		g_mainWindowFocusTrackerMutex);
+	std::lock_guard<decltype(g_AppActiveTrackerMutex)> guard(
+		g_AppActiveTrackerMutex);
 
-	g_mainWindowFocusTrackerWidgets.erase(widget);
+	g_AppActiveTrackerWidgets.erase(widget);
 
-	if (g_mainWindowFocusTrackerWidgets.size() == 0) {
-		ShutdownMainWindowFocusTracker();
+	if (g_AppActiveTrackerWidgets.size() == 0) {
+		ShutdownAppActiveTracker();
 	}
 }
 
@@ -177,12 +228,12 @@ StreamElementsBrowserWidget::StreamElementsBrowserWidget(
 	policy.setVerticalPolicy(QSizePolicy::MinimumExpanding);
 	setSizePolicy(policy);
 
-	RegisterMainWindowFocusTrackerWidget(this);
+	RegisterAppActiveTrackerWidget(this);
 }
 
 StreamElementsBrowserWidget::~StreamElementsBrowserWidget()
 {
-	UnRegisterMainWindowFocusTrackerWidget(this);
+	UnregisterAppActiveTrackerWidget(this);
 
 	DestroyBrowser();
 }

--- a/streamelements/StreamElementsBrowserWidget.cpp
+++ b/streamelements/StreamElementsBrowserWidget.cpp
@@ -543,3 +543,16 @@ void StreamElementsBrowserWidget::BrowserPaste()
 
 	frame->Paste();
 }
+
+void StreamElementsBrowserWidget::BrowserSelectAll()
+{
+	if (!m_cef_browser.get())
+		return;
+
+	CefRefPtr<CefFrame> frame = m_cef_browser->GetFocusedFrame();
+
+	if (!frame.get())
+		return;
+
+	frame->SelectAll();
+}

--- a/streamelements/StreamElementsBrowserWidget.hpp
+++ b/streamelements/StreamElementsBrowserWidget.hpp
@@ -387,6 +387,7 @@ public:
 	void BrowserCopy();
 	void BrowserCut();
 	void BrowserPaste();
+	void BrowserSelectAll();
 
 	class StreamElementsBrowserWidget_EventHandler :
 		public StreamElementsCefClientEventHandler

--- a/streamelements/StreamElementsBrowserWidget.hpp
+++ b/streamelements/StreamElementsBrowserWidget.hpp
@@ -367,19 +367,31 @@ protected:
 		}
 	}
 
-
-
-
 private:
 	std::mutex m_create_destroy_mutex;
 
 signals:
 	void browserStateChanged();
+	void browserFocusedDOMNodeEditableChanged(bool isEditable);
+
+public:
+	bool isBrowserFocusedDOMNodeEditable() { return m_isBrowserFocusedDOMNodeEditable; }
 
 private:
 	void emitBrowserStateChanged()
 	{
 		emit browserStateChanged();
+	}
+
+	bool m_isBrowserFocusedDOMNodeEditable = false;
+	void setBrowserFocusedDOMNodeEditable(bool isEditable)
+	{
+		if (isEditable == m_isBrowserFocusedDOMNodeEditable)
+			return;
+
+		m_isBrowserFocusedDOMNodeEditable = isEditable;
+
+		emit browserFocusedDOMNodeEditableChanged(isEditable);
 	}
 
 	class StreamElementsBrowserWidget_EventHandler :
@@ -413,6 +425,15 @@ private:
 
 				widget->setFocus();
 			}, m_widget);
+		}
+
+		virtual void OnFocusedDOMNodeChanged(CefRefPtr<CefBrowser>,
+						     bool isEditable) override
+		{
+			QtPostTask([this, isEditable]() {
+				m_widget->setBrowserFocusedDOMNodeEditable(
+					isEditable);
+			});
 		}
 
 	private:

--- a/streamelements/StreamElementsBrowserWidget.hpp
+++ b/streamelements/StreamElementsBrowserWidget.hpp
@@ -211,19 +211,8 @@ protected:
 		}
 	}
 
-	virtual void focusInEvent(QFocusEvent* event) override
-	{
-		QWidget::focusInEvent(event);
-
-		blog(LOG_INFO, "QWidget::focusInEvent: reason %d: %s", event->reason(), m_url.c_str());
-	}
-
-	virtual void focusOutEvent(QFocusEvent* event) override
-	{
-		QWidget::focusOutEvent(event);
-
-		blog(LOG_INFO, "QWidget::focusOutEvent: %s", m_url.c_str());
-	}
+	virtual void focusInEvent(QFocusEvent *event) override;
+	virtual void focusOutEvent(QFocusEvent *event) override;
 
 private:
 	void UpdateBrowserSize()
@@ -393,6 +382,11 @@ private:
 
 		emit browserFocusedDOMNodeEditableChanged(isEditable);
 	}
+
+public:
+	void BrowserCopy();
+	void BrowserCut();
+	void BrowserPaste();
 
 	class StreamElementsBrowserWidget_EventHandler :
 		public StreamElementsCefClientEventHandler

--- a/streamelements/StreamElementsCefClient.cpp
+++ b/streamelements/StreamElementsCefClient.cpp
@@ -291,6 +291,14 @@ bool StreamElementsCefClient::OnProcessMessageReceived(
 		return true;
 	}
 #endif
+	else if (name == "CefRenderProcessHandler::OnFocusedNodeChanged") {
+		bool isEditable = message->GetArgumentList()->GetBool(0);
+
+		if (!!m_eventHandler) {
+			m_eventHandler->OnFocusedDOMNodeChanged(browser,
+								isEditable);
+		}
+	}
 	else {
 
 		return false;

--- a/streamelements/StreamElementsCefClient.hpp
+++ b/streamelements/StreamElementsCefClient.hpp
@@ -30,6 +30,12 @@ public:
 	virtual void OnGotFocus(CefRefPtr<CefBrowser>) {
 	}
 
+	virtual void OnFocusedDOMNodeChanged(CefRefPtr<CefBrowser>,
+					     bool isEditable)
+	{
+		UNREFERENCED_PARAMETER(isEditable);
+	}
+
 public:
 	IMPLEMENT_REFCOUNTING(StreamElementsCefClientEventHandler);
 };

--- a/streamelements/StreamElementsMenuManager.cpp
+++ b/streamelements/StreamElementsMenuManager.cpp
@@ -57,16 +57,19 @@ void StreamElementsMenuManager::AddMenuActions()
 	m_cefEditMenuActionCopy = new QAction("Copy");
 	m_cefEditMenuActionCut = new QAction("Cut");
 	m_cefEditMenuActionPaste = new QAction("Paste");
+	m_cefEditMenuActionSelectAll = new QAction("Select All");
 
 	m_cefEditMenuActionCopy->setShortcut(QKeySequence::Copy);
 	m_cefEditMenuActionCut->setShortcut(QKeySequence::Cut);
 	m_cefEditMenuActionPaste->setShortcut(QKeySequence::Paste);
+	m_cefEditMenuActionSelectAll->setShortcut(QKeySequence::SelectAll);
 
-		const bool isEditable =
+	const bool isEditable =
 		m_focusedBrowserWidget->isBrowserFocusedDOMNodeEditable();
 
 	m_cefEditMenuActionCopy->setEnabled(isEditable);
 	m_cefEditMenuActionCut->setEnabled(isEditable);
+	m_cefEditMenuActionSelectAll->setEnabled(isEditable);
 
 	auto mimeData = qApp->clipboard()->mimeData();
 
@@ -77,13 +80,20 @@ void StreamElementsMenuManager::AddMenuActions()
 	m_cefEditMenuActions.push_back(m_cefEditMenuActionCopy);
 	m_cefEditMenuActions.push_back(m_cefEditMenuActionCut);
 	m_cefEditMenuActions.push_back(m_cefEditMenuActionPaste);
+	m_cefEditMenuActions.push_back(m_cefEditMenuActionSelectAll);
 
+	m_cefEditMenuActions.push_back(
+		m_editMenu->insertSeparator(m_editMenu->actions().at(0)));
+	m_editMenu->insertAction(m_editMenu->actions().at(0),
+				 m_cefEditMenuActionSelectAll);
+	m_cefEditMenuActions.push_back(
+		m_editMenu->insertSeparator(m_editMenu->actions().at(0)));
 	m_editMenu->insertAction(m_editMenu->actions().at(0),
 				 m_cefEditMenuActionPaste);
 	m_editMenu->insertAction(m_editMenu->actions().at(0),
-				 m_cefEditMenuActionCut);
-	m_editMenu->insertAction(m_editMenu->actions().at(0),
 				 m_cefEditMenuActionCopy);
+	m_editMenu->insertAction(m_editMenu->actions().at(0),
+				 m_cefEditMenuActionCut);
 
 	QObject::connect(m_cefEditMenuActionCopy, &QAction::triggered, this,
 			 &StreamElementsMenuManager::HandleCefCopy);
@@ -91,6 +101,9 @@ void StreamElementsMenuManager::AddMenuActions()
 			 &StreamElementsMenuManager::HandleCefCut);
 	QObject::connect(m_cefEditMenuActionPaste, &QAction::triggered, this,
 			 &StreamElementsMenuManager::HandleCefPaste);
+	QObject::connect(m_cefEditMenuActionSelectAll, &QAction::triggered,
+			 this,
+			 &StreamElementsMenuManager::HandleCefSelectAll);
 }
 
 void StreamElementsMenuManager::RemoveMenuActions()
@@ -104,6 +117,9 @@ void StreamElementsMenuManager::RemoveMenuActions()
 			    &StreamElementsMenuManager::HandleCefCut);
 	QObject::disconnect(m_cefEditMenuActionPaste, &QAction::triggered, this,
 			    &StreamElementsMenuManager::HandleCefPaste);
+	QObject::disconnect(m_cefEditMenuActionSelectAll, &QAction::triggered,
+			    this,
+			    &StreamElementsMenuManager::HandleCefSelectAll);
 
 	for (auto i : m_cefEditMenuActions) {
 		m_editMenu->removeAction(i);
@@ -171,6 +187,16 @@ void StreamElementsMenuManager::HandleCefPaste()
 		return;
 
 	m_focusedBrowserWidget->BrowserPaste();
+}
+
+void StreamElementsMenuManager::HandleCefSelectAll()
+{
+	// Must be called on QT app thread
+
+	if (!m_focusedBrowserWidget)
+		return;
+
+	m_focusedBrowserWidget->BrowserSelectAll();
 }
 
 void StreamElementsMenuManager::HandleFocusedWidgetDOMNodeEditableChanged(

--- a/streamelements/StreamElementsMenuManager.cpp
+++ b/streamelements/StreamElementsMenuManager.cpp
@@ -229,6 +229,13 @@ void StreamElementsMenuManager::UpdateEditMenuInternal()
 
 	m_nativeEditMenuCopySourceAction->setVisible(!editMenuVisible);
 
+	if (editMenuVisible) {
+		m_nativeEditMenuCopySourceAction->setShortcut(QKeySequence());
+	} else {
+		m_nativeEditMenuCopySourceAction->setShortcut(
+			QKeySequence::Copy);
+	}
+
 	RemoveMenuActions();
 
 	if (editMenuVisible) {

--- a/streamelements/StreamElementsMenuManager.cpp
+++ b/streamelements/StreamElementsMenuManager.cpp
@@ -21,6 +21,8 @@ StreamElementsMenuManager::StreamElementsMenuManager(QMainWindow *parent)
 	m_menu = new QMenu("St&reamElements");
 
 	mainWindow()->menuBar()->addMenu(m_menu);
+	m_editMenu = mainWindow()->menuBar()->findChild<QMenu *>(
+		"menuBasic_MainMenu_Edit");
 
 	LoadConfig();
 }

--- a/streamelements/StreamElementsMenuManager.hpp
+++ b/streamelements/StreamElementsMenuManager.hpp
@@ -46,9 +46,9 @@ protected:
 
 private:
 	void UpdateInternal();
-	void UpdateEditMenuInternal();
+	void UpdateOBSEditMenuInternal();
 
-	void HandleFocusedWidgetDOMNodeEditableChanged(bool isEditable);
+	void HandleFocusedBrowserWidgetDOMNodeEditableChanged(bool isEditable);
 	void HandleClipboardDataChanged();
 
 	void HandleCefCopy();
@@ -56,21 +56,43 @@ private:
 	void HandleCefPaste();
 	void HandleCefSelectAll();
 
-	void AddMenuActions();
-	void RemoveMenuActions();
+	void AddOBSEditMenuActions();
+	void RemoveOBSEditMenuActions();
 
 private:
 	QMainWindow* m_mainWindow;
 	QMenu *m_menu;
 
+	//
+	// OBS-native Edit menu.
+	//
 	QMenu *m_editMenu;
-	std::vector<QAction *> m_cefEditMenuActions;
-	QAction *m_cefEditMenuActionCopy = nullptr;
-	QAction *m_cefEditMenuActionCut = nullptr;
-	QAction *m_cefEditMenuActionPaste = nullptr;
-	QAction *m_cefEditMenuActionSelectAll = nullptr;
-	QAction *m_nativeEditMenuCopySourceAction = nullptr;
 
+	//
+	// Our actions to be added under OBS-native Edit
+	// menu when appropriate (see m_focusedBrowserWidget
+	// below for further details).
+	//
+	std::vector<QAction *> m_cefOBSEditMenuActions;
+	QAction *m_cefOBSEditMenuActionCopy = nullptr;
+	QAction *m_cefOBSEditMenuActionCut = nullptr;
+	QAction *m_cefOBSEditMenuActionPaste = nullptr;
+	QAction *m_cefOBSEditMenuActionSelectAll = nullptr;
+
+	//
+	// OBS-native Edit->Copy menu item.
+	//
+	QAction *m_nativeOBSEditMenuCopySourceAction = nullptr;
+
+	//
+	// Indicates which browser widget is currently in focus.
+	//
+	// When a browser widget is in focus and it's internally
+	// focused DOM node is an editable element, we'll show
+	// Cut/Copy/Paste/Select All items under the OBS native
+	// "Edit" menu. We'll also hide & disable the OBS-native
+	// "Copy" action.
+	//
 	StreamElementsBrowserWidget *m_focusedBrowserWidget = nullptr;
 
 	CefRefPtr<CefValue> m_auxMenuItems = CefValue::Create();

--- a/streamelements/StreamElementsMenuManager.hpp
+++ b/streamelements/StreamElementsMenuManager.hpp
@@ -55,6 +55,9 @@ private:
 	void HandleCefCut();
 	void HandleCefPaste();
 
+	void AddMenuActions();
+	void RemoveMenuActions();
+
 private:
 	QMainWindow* m_mainWindow;
 	QMenu *m_menu;

--- a/streamelements/StreamElementsMenuManager.hpp
+++ b/streamelements/StreamElementsMenuManager.hpp
@@ -42,7 +42,8 @@ private:
 
 private:
 	QMainWindow* m_mainWindow;
-	QMenu* m_menu;
+	QMenu *m_menu;
+	QMenu *m_editMenu;
 	CefRefPtr<CefValue> m_auxMenuItems = CefValue::Create();
 	bool m_showBuiltInMenuItems = true;
 };

--- a/streamelements/StreamElementsMenuManager.hpp
+++ b/streamelements/StreamElementsMenuManager.hpp
@@ -3,7 +3,9 @@
 #include "cef-headers.hpp"
 
 #include "StreamElementsApiMessageHandler.hpp"
+#include "StreamElementsBrowserWidget.hpp"
 
+#include <QObject>
 #include <QMainWindow>
 #include <QMenuBar>
 #include <QMenu>
@@ -11,8 +13,11 @@
 #include <string>
 #include <vector>
 
-class StreamElementsMenuManager
+class StreamElementsMenuManager :
+	public QObject
 {
+	Q_OBJECT;
+
 private:
 	enum aux_menu_item_type_t { Command, Separator, Container };
 
@@ -31,6 +36,8 @@ public:
 	void SetShowBuiltInMenuItems(bool show);
 	bool GetShowBuiltInMenuItems();
 
+	void SetFocusedBrowserWidget(StreamElementsBrowserWidget *widget);
+
 protected:
 	QMainWindow* mainWindow() { return m_mainWindow; }
 
@@ -39,11 +46,28 @@ protected:
 
 private:
 	void UpdateInternal();
+	void UpdateEditMenuInternal();
+
+	void HandleFocusedWidgetDOMNodeEditableChanged(bool isEditable);
+	void HandleClipboardDataChanged();
+
+	void HandleCefCopy();
+	void HandleCefCut();
+	void HandleCefPaste();
 
 private:
 	QMainWindow* m_mainWindow;
 	QMenu *m_menu;
+
 	QMenu *m_editMenu;
+	std::vector<QAction *> m_cefEditMenuActions;
+	QAction *m_cefEditMenuActionCopy = nullptr;
+	QAction *m_cefEditMenuActionCut = nullptr;
+	QAction *m_cefEditMenuActionPaste = nullptr;
+	QAction *m_nativeEditMenuCopySourceAction = nullptr;
+
+	StreamElementsBrowserWidget *m_focusedBrowserWidget = nullptr;
+
 	CefRefPtr<CefValue> m_auxMenuItems = CefValue::Create();
 	bool m_showBuiltInMenuItems = true;
 };

--- a/streamelements/StreamElementsMenuManager.hpp
+++ b/streamelements/StreamElementsMenuManager.hpp
@@ -54,6 +54,7 @@ private:
 	void HandleCefCopy();
 	void HandleCefCut();
 	void HandleCefPaste();
+	void HandleCefSelectAll();
 
 	void AddMenuActions();
 	void RemoveMenuActions();
@@ -67,6 +68,7 @@ private:
 	QAction *m_cefEditMenuActionCopy = nullptr;
 	QAction *m_cefEditMenuActionCut = nullptr;
 	QAction *m_cefEditMenuActionPaste = nullptr;
+	QAction *m_cefEditMenuActionSelectAll = nullptr;
 	QAction *m_nativeEditMenuCopySourceAction = nullptr;
 
 	StreamElementsBrowserWidget *m_focusedBrowserWidget = nullptr;


### PR DESCRIPTION
* Reliable `focusIn`/`focusOut` events on Windows
  on browser widgets implemented via Win32 Hooks.
 
* Detection of selected DOM node type for browser
  widgets (editable / non-editable).

* Edit menu items specific to browser widgets:
  Cut, Copy, Paste, Select All
