### PR TITLE
Fix double click required to begin typing in chat

### DIFF
--- a/streamelements/StreamElementsBrowserWidget.cpp
+++ b/streamelements/StreamElementsBrowserWidget.cpp
@@ -534,6 +534,11 @@ void StreamElementsBrowserWidget::focusInEvent(QFocusEvent *event)
 	StreamElementsGlobalStateManager::GetInstance()
 		->GetMenuManager()
 		->SetFocusedBrowserWidget(this);
+
+	if (!!m_cef_browser.get() && m_cef_browser->GetHost()) {
+		// Notify CEF that it got focus
+		m_cef_browser->GetHost()->SetFocus(true);
+	}
 }
 
 void StreamElementsBrowserWidget::focusOutEvent(QFocusEvent *event)
@@ -553,6 +558,11 @@ void StreamElementsBrowserWidget::focusOutEvent(QFocusEvent *event)
 		StreamElementsGlobalStateManager::GetInstance()
 			->GetMenuManager()
 			->SetFocusedBrowserWidget(nullptr);
+
+		if (!!m_cef_browser.get() && m_cef_browser->GetHost()) {
+			// Notify CEF that it lost focus
+			m_cef_browser->GetHost()->SetFocus(false);
+		}
 	}
 }
 


### PR DESCRIPTION
* CEF browser was not always automatically receiving input focus when
  Browser Widget was receiving focus.

* This resulted in the user sometimes having to click chat input field
  twice before they were able to type.

* Sync CEF browser focus to it's parent Browser Widget input focus
  state.