### PR TITLE
API 2.2: backup: huge referenced files handling

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -2032,6 +2032,17 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 	}
 	API_HANDLER_END();
 
+	API_HANDLER_BEGIN("queryUserEnvironmentBackupReferencedFiles");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetBackupManager()
+				->QueryLocalBackupPackageReferencedFiles(
+					args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
 	API_HANDLER_BEGIN("createUserEnvironmentBackupPackage");
 	{
 		if (args->GetSize()) {

--- a/streamelements/StreamElementsBackupManager.hpp
+++ b/streamelements/StreamElementsBackupManager.hpp
@@ -10,6 +10,10 @@ public:
 	~StreamElementsBackupManager();
 
 public:
+	void
+	QueryLocalBackupPackageReferencedFiles(CefRefPtr<CefValue> input,
+					       CefRefPtr<CefValue> &output);
+
 	void CreateLocalBackupPackage(CefRefPtr<CefValue> input,
 					 CefRefPtr<CefValue> &output);
 

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 1
+#define HOST_API_VERSION_MINOR 2
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
Add facilities to
(a) skip huge referenced files during backup and
(b) perform pre-flight check to detect files which cannot be backed up
    so the user can be informed in advance and offered a choice to
    either continue or cancel backup.

Add API methods:

* queryUserEnvironmentBackupReferencedFiles

Add Data Structures:

* BackupReferencedFileInfo

Add Properties:

* SceneCollectionInfo.referencedFiles